### PR TITLE
js/import/import should use global

### DIFF
--- a/dom/mutate/mutate-test.js
+++ b/dom/mutate/mutate-test.js
@@ -1,5 +1,5 @@
 var mutate = require('./mutate');
-var MUTATION_OBSERVER = require("can-util/dom/mutation-observer/mutation-observer");
+var MUTATION_OBSERVER = require("../mutation-observer/mutation-observer");
 
 QUnit = require('steal-qunit');
 

--- a/js/global/global-test.js
+++ b/js/global/global-test.js
@@ -11,3 +11,19 @@ test("basics", function(){
 		ok(getGlobal() === global);
 	}
 });
+
+if(!isBrowserWindow()) {
+	QUnit.module("in Node with fake window", {
+		setup: function(){
+			this.oldWindow = global.window;
+			global.window = {};
+		},
+		teardown: function(){
+			global.window = this.oldWindow;
+		}
+	});
+
+	test("Gets the Node global", function(){
+		ok(getGlobal() === global);
+	});
+}

--- a/js/global/global.js
+++ b/js/global/global.js
@@ -1,6 +1,13 @@
 /* global self */
 /* global WorkerGlobalScope */
 module.exports = function(){
-	return typeof window !== "undefined" ? window :
-		(typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope) ? self : global;
+	// Web Worker
+	return (typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope) ? self :
+
+		// Node.js
+		typeof process === "object" &&
+		{}.toString.call(process) === "[object process]" ? global :
+		
+		// Browser window
+		window;
 };

--- a/js/import/import-test.js
+++ b/js/import/import-test.js
@@ -1,11 +1,50 @@
 var QUnit = require('../../test/qunit');
 var load = require('./import');
+var isNode = require('../is-node/is-node')();
 
-QUnit.module('can-util/js/import');
+if(!isNode) {
+	QUnit.module('can-util/js/import');
 
-QUnit.asyncTest('basic can-import works', function() {
-	load('can-util/js/import/testmodule').then(function(data) {
-		QUnit.equal(data, 'Hello world');
-		start();
+	QUnit.test('basic can-import works', function() {
+		stop();
+
+		load('can-util/js/import/testmodule', __dirname).then(function(data) {
+			QUnit.equal(data, 'Hello world');
+		}).then(null, function(err){
+			QUnit.ok(false, err);
+		}).then(start, start);
 	});
-});
+} else {
+	QUnit.module('can-util/js/import - Node', {
+		setup: function(){
+			// Create a fake System.import
+			this.oldSystem = global.System;
+			global.System = {
+				"import": function(name){
+					name = name.replace("can-util", "");
+
+					return new Promise(function(resolve, reject){
+						try {
+							var mod = require(process.cwd() + name);
+							resolve(mod);
+						} catch(err) {
+							reject(err);
+						}
+					});
+				}
+			};
+		},
+		teardown: function(){
+			global.System = this.oldSystem;
+		}
+	});
+
+	QUnit.test('basic can-import works', function() {
+		stop();
+		load('can-util/js/import/testmodule', __dirname).then(function(data) {
+			QUnit.equal(data, 'Hello world');
+		}).then(null, function(err){
+			QUnit.ok(false, err);
+		}).then(start, start);
+	});
+}

--- a/js/import/import.js
+++ b/js/import/import.js
@@ -1,20 +1,25 @@
 var isFunction = require('../is-function/is-function');
+var global = require("../global/global")();
 
 module.exports = function(moduleName, parentName) {
 	return new Promise(function(resolve, reject) {
-		if(typeof window.System === "object" && isFunction(window.System["import"])) {
-			window.System["import"](moduleName, {
-				name: parentName
-			}).then(resolve, reject);
-		} else if(window.define && window.define.amd){
-			window.require([moduleName], function(value){
-				resolve(value);
-			});
-		} else if(window.require){
-			resolve(window.require(moduleName));
-		} else {
-			// ideally this will use can.getObject
-			resolve();
+		try {
+			if(typeof global.System === "object" && isFunction(global.System["import"])) {
+				global.System["import"](moduleName, {
+					name: parentName
+				}).then(resolve, reject);
+			} else if(global.define && global.define.amd){
+				global.require([moduleName], function(value){
+					resolve(value);
+				});
+			} else if(global.require){
+				resolve(global.require(moduleName));
+			} else {
+				// ideally this will use can.getObject
+				resolve();
+			}
+		} catch(err) {
+			reject(err);
 		}
 	});
 };

--- a/package.json
+++ b/package.json
@@ -46,9 +46,6 @@
     ],
     "npmAlgorithm": "flat"
   },
-  "dependencies": {
-    "can-util": "^3.0.0-pre.21"
-  },
   "devDependencies": {
     "cssify": "^0.6.0",
     "documentjs": "^0.4.2",


### PR DESCRIPTION
This makes js/import/import use `global.System`, so that it will work in
Node.
