### PR TITLE
Fire inserted against canNamespace.document

### DIFF
--- a/dom/mutate/mutate-test.js
+++ b/dom/mutate/mutate-test.js
@@ -1,13 +1,21 @@
 var mutate = require('./mutate');
 var MUTATION_OBSERVER = require("../mutation-observer/mutation-observer");
+var canNamespace = require("../../namespace");
 
 QUnit = require('steal-qunit');
 
 QUnit.module("can-util/dom/mutate");
 
-test("inserting empty frag", function () {
+function disableMO(){
 	var old = MUTATION_OBSERVER();
 	MUTATION_OBSERVER(null);
+	return function(){
+		MUTATION_OBSERVER(old);
+	};
+}
+
+test("inserting empty frag", function () {
+	var enableMO = disableMO();
 
 	var frag = document.createDocumentFragment();
 	mutate.appendChild.call( document.getElementById("qunit-fixture"), frag );
@@ -19,8 +27,32 @@ test("inserting empty frag", function () {
 	mutate.appendChild.call( document.getElementById("qunit-fixture"), div );
 	stop();
 	setTimeout(function(){
-		MUTATION_OBSERVER(old);
+		enableMO();
 		start();
 	},10);
 
+});
+
+test("inserting into a different document fires inserted", function(){
+	var enableMO = disableMO();
+
+	var doc = document.createElement("html");
+	doc.body = document.createElement("body");
+	doc.appendChild(doc.body);
+
+	var oldDoc = canNamespace.document;
+	canNamespace.document = doc;
+
+	var div = document.createElement("div");
+	div.addEventListener("inserted", function(){
+		ok(true, "called");
+	});
+	mutate.appendChild.call(doc.body, div);
+
+	stop();
+	setTimeout(function(){
+		enableMO();
+		canNamespace.document = oldDoc;
+		start();
+	}, 10);
 });

--- a/dom/mutate/mutate.js
+++ b/dom/mutate/mutate.js
@@ -10,6 +10,7 @@ var getMutationObserver = require("../mutation-observer/mutation-observer");
 var childNodes = require("../child-nodes/child-nodes");
 var domContains = require("../contains/contains");
 var domDispatch = require("../dispatch/dispatch");
+var canNamespace = require("../../namespace");
 
 
 var mutatedElements;
@@ -59,7 +60,7 @@ var fireMutations = function(){
 	mutatedElements = null;
 
 	var firstElement = mutations[0][1][0];
-	var doc = firstElement.ownerDocument || firstElement;
+	var doc = canNamespace.document || firstElement.ownerDocument || firstElement;
 	var root = doc.contains ? doc : doc.body;
 	var dispatched = {inserted: {}, removed: {}};
 	mutations.forEach(function(mutation){
@@ -70,7 +71,7 @@ var mutated = function(elements, type) {
 	if(!getMutationObserver() && elements.length) {
 		// make sure this element is in the page (mutated called before something is removed)
 		var firstElement = elements[0];
-		var doc = firstElement.ownerDocument || firstElement;
+		var doc = canNamespace.document || firstElement.ownerDocument || firstElement;
 		var root = doc.contains ? doc : doc.body;
 		if( checks.inserted(root, firstElement) ) {
 


### PR DESCRIPTION
Before firing the "inserted" event we first check that an element is in
the document. In server-side rendering the ownerDocument is usually not
the document the element was inserted into.

Because of this, this change makes it so that we check against
`canNamespace.document`. In SSR scenarios we will use a Zone to set this
property to be the document the element is being inserted into.

Closes #17
