### PR TITLE
matches should return false for document

### DIFF
--- a/dom/matches/matches-test.html
+++ b/dom/matches/matches-test.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+	<title>matches tests</title>
+</head>
+<body>
+<div id="qunit-fixture"></div>
+<script src="../../node_modules/steal/steal.js"
+		data-main="can-util/dom/matches/matches-test"></script>
+</body>
+</html>

--- a/dom/matches/matches-test.js
+++ b/dom/matches/matches-test.js
@@ -1,0 +1,18 @@
+var matches = require("./matches");
+
+QUnit = require("steal-qunit");
+
+QUnit.module("can-util/dom/matches");
+
+QUnit.test("basics", function(){
+	var a = document.createElement("a");
+	a.id = "foo";
+
+	QUnit.ok(matches.call(a, "#foo"), "matches selector");
+});
+
+QUnit.test("returns false for document", function(){
+	var res = matches.call(document, "a");
+
+	QUnit.equal(res, false, "document never matches");
+});

--- a/dom/matches/matches.js
+++ b/dom/matches/matches.js
@@ -4,5 +4,6 @@ var matchesMethod = function(element) {
 };
 
 module.exports = function(){
-	return matchesMethod(this).apply(this, arguments);
+	var method = matchesMethod(this);
+	return method ? method.apply(this, arguments) : false;
 };

--- a/dom/tests.js
+++ b/dom/tests.js
@@ -5,3 +5,4 @@ require("./events/delegate/delegate-test");
 require("./events/inserted/inserted-test");
 require("./events/removed/removed-test");
 require("./mutate/mutate-test");
+require("./matches/matches-test");


### PR DESCRIPTION
the document doesn't have a matches method, and in reality should never
match anyways, so returning false when a matches method doesn't
exist.
