### PR TITLE
Small fixes to make can.ajax accessible & familiar

### DIFF
--- a/dom/ajax/ajax.js
+++ b/dom/ajax/ajax.js
@@ -85,7 +85,7 @@ module.exports = function (o) {
 			if( xhr.status === 200 ) {
 				deferred.resolve( JSON.parse( xhr.responseText ) );
 			} else {
-				deferred.reject( JSON.parse( xhr.responseText ) );
+				deferred.reject( [xhr, xhr.statusText, JSON.parse( xhr.responseText )] );
 			}
 		}
 		else if (o.progress) {

--- a/dom/ajax/ajax.js
+++ b/dom/ajax/ajax.js
@@ -85,7 +85,7 @@ module.exports = function (o) {
 			if( xhr.status === 200 ) {
 				deferred.resolve( JSON.parse( xhr.responseText ) );
 			} else {
-				deferred.reject( [xhr, xhr.statusText, JSON.parse( xhr.responseText )] );
+				deferred.reject( xhr );
 			}
 		}
 		else if (o.progress) {

--- a/dom/dom.js
+++ b/dom/dom.js
@@ -5,6 +5,7 @@
  */
 
 module.exports = {
+	ajax: require('./ajax/ajax'),
 	attr: require('./attr/attr'),
 	childNodes: require('./child-nodes/child-nodes'),
 	className: require('./class-name/class-name'),


### PR DESCRIPTION
`ajax()` wasn't previously part of the `dom` export, and its rejection on error only contained the response text.

It's up for debate whether the latter issue is an issue at all (& please discuss), but the tests for can-model expected the XHR to be returned, so I added it in here.
