### PR TITLE
Fix issue #24

### DIFF
--- a/js/is-empty-object/is-empty-object.js
+++ b/js/is-empty-object/is-empty-object.js
@@ -5,7 +5,7 @@
  * @parent can-util/js
  * @signature `isEmptyObject(obj)`
  *
- * Used to determine if an object is an empty object (an object with no properties) such as `{}`.
+ * Used to determine if an object is an empty object (an object with no enumerable properties) such as `{}`.
  *
  * ```js
  * var isEmptyObject = require("can-util/js/is-empty-object/is-empty-object");
@@ -13,10 +13,17 @@
  * console.log(isEmptyObject({})); // -> true
  *
  * console.log(isEmptyObject({ a: 1 })); // -> false
+ *
+ * var obj = {};
+ * Object.defineProperty(obj, "foo", {
+ *     enumerable: false,
+ *     value: "bar"
+ * });
+ * console.log(isEmptyObject(obj)); // -> true
  * ```
  *
  * @param {Object} obj Any object.
- * @return {Boolean} True if the object is an object with no properties.
+ * @return {Boolean} True if the object is an object with no enumerable properties.
  */
 module.exports = function(obj){
 	for(var prop in obj) {


### PR DESCRIPTION
Fix issue #24 (isEmptyObject returns true when there is a non-enumerable property)

isEmptyObject is expected to return true if the object contains no enumerable properties. This is, therefore, not a defect. Update docs to clearly spell out the behavior in case the object contains a non-enumerable property.
