### PR TITLE
Adds types.wrapElement and types.unwrapElement

### DIFF
--- a/js/types/test.html
+++ b/js/types/test.html
@@ -1,0 +1,2 @@
+<title>can-util/js/types/types tests</title>
+<script src="../../node_modules/steal/steal.js" main="can-util/js/types/types-test"></script>

--- a/js/types/types-test.js
+++ b/js/types/types-test.js
@@ -1,5 +1,6 @@
 var QUnit = require('../../test/qunit');
 var types = require('./types');
+var DOCUMENT = require("../../dom/document/document");
 
 QUnit.module("can-util/js/types");
 
@@ -11,3 +12,20 @@ QUnit.test('types.isConstructor', function () {
 	ok(!types.isConstructor(Constructor.prototype.method));
 
 });
+
+// Only run this in an environment with a document
+if(DOCUMENT()) {
+
+	QUnit.test("types.wrapElement", function() {
+		var el = DOCUMENT().createElement("div");
+
+		equal(el, types.wrapElement(el), "is an identity function by default");
+	});
+
+	QUnit.test("types.unwrapElement", function() {
+		var el = DOCUMENT().createElement("div");
+
+		equal(el, types.unwrapElement(el), "is an identity function by default");
+	});
+
+}

--- a/js/types/types.js
+++ b/js/types/types.js
@@ -116,6 +116,28 @@ var types = {
 	 *   The default list type to create if a list is needed. If both [can-list] and [can-define/list/list]
 	 *   are imported, the default type will be [can-define/list/list].
 	 */
-	DefaultList: null
+	DefaultList: null,
+	/**
+	 * @function can-util/js/types/types.wrapElement wrapElement
+	 * @signature `types.wrapElement(element)`
+	 *   Wraps an element into an object useful by DOM libraries ala jQuery.
+	 *
+	 *   @param {Node} element Any object inheriting from the [Node interface](https://developer.mozilla.org/en-US/docs/Web/API/Node).
+	 *   @return {{}} A wrapped object.
+	 */
+	wrapElement: function(element){
+		return element;
+	},
+	/**
+	 * @function can-util/js/types/types.unwrapElement unwrapElement
+	 * @signature `types.unwrapElement(object)`
+	 *   Unwraps an object that contains an element within.
+	 *
+	 *   @param {{}} object Any object that can be unwrapped into a Node.
+	 *   @return {Node} A Node.
+	 */
+	unwrapElement: function(element){
+		return element;
+	}
 };
 module.exports = types;


### PR DESCRIPTION
Closes #39

This provides two new types methods:
- `wrapElement(element)` takes an element and wraps it. can-jquery will use this to create a jQuery object.
- `unwrapElement(object)` takes a wrapped object and returns the raw element. can-jquery will use this to provide the element again.
