### PR TITLE
Adds support for iterables to each

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -22,6 +22,7 @@
 		"stop": true,
 		"global": true,
 		"Promise": true,
+		"Symbol": true,
 		"ActiveXObject": true
 	},
 	"strict": false,

--- a/js/each/each-test.js
+++ b/js/each/each-test.js
@@ -1,5 +1,6 @@
 var QUnit = require('../../test/qunit');
 var each  = require('./each');
+var types = require('../types/types');
 
 QUnit.module('can-util/js/each');
 
@@ -27,4 +28,28 @@ test('#1989 - isArrayLike needs to check for object type', function() {
   } catch(e) {
     ok(false, 'Should not fail');
   }
+});
+
+test("objects that implement iterators work", function() {
+	var Ctr = function(){};
+	Ctr.prototype[types.iterator] = function(){
+		return {
+			i: 0,
+			next: function(){
+				if(this.i === 1) {
+					return { value: undefined, done: true };
+				}
+				this.i++;
+
+				return { value: ["a", "b"], done: false };
+			}
+		};
+	};
+
+	var obj = new Ctr();
+
+	each(obj, function(value, key){
+		equal(key, "a");
+		equal(value, "b");
+	});
 });

--- a/js/each/each.js
+++ b/js/each/each.js
@@ -1,6 +1,8 @@
 /* jshint maxdepth:7*/
 var isArrayLike = require('../is-array-like/is-array-like');
 var has = Object.prototype.hasOwnProperty;
+var isIterable = require("../is-iterable/is-iterable");
+var types = require("../types/types");
 
 function each(elements, callback, context) {
 	var i = 0,
@@ -15,6 +17,17 @@ function each(elements, callback, context) {
 				if (callback.call(context || item, item, i, elements) === false) {
 					break;
 				}
+			}
+		}
+		// Works in anything that implements Symbol.iterator
+		else if(isIterable(elements)) {
+			var iter = elements[types.iterator]();
+			var res, value;
+
+			while(!(res = iter.next()).done) {
+				value = res.value;
+				callback.call(context || elements, Array.isArray(value) ?
+											value[1] : value, value[0]);
 			}
 		}
 		 else if (typeof elements === "object") {

--- a/js/is-iterable/is-iterable.js
+++ b/js/is-iterable/is-iterable.js
@@ -1,0 +1,5 @@
+var types = require("../types/types");
+
+module.exports = function(obj) {
+	return obj && !!obj[types.iterator];
+};

--- a/js/tests.js
+++ b/js/tests.js
@@ -9,7 +9,7 @@ require('./diff-array/diff-array-test');
 require('./diff-object/diff-object-test');
 
 // TODO - Depends on can.Map, can.List
-// require('./each/each-test');
+require('./each/each-test');
 
 require('./global/global-test');
 require('./import/import-test');

--- a/js/types/types.js
+++ b/js/types/types.js
@@ -100,6 +100,13 @@ var types = {
 		return obj && obj.isComputed;
 	},
 	/**
+	 * @property {Symbol} can-util/js/types/types.iterator iterator
+	 * @option {Symbol}
+	 *
+	 * Used to implement an iterable object that can be used with [can-util/js/each/each]. In browsers that support for/of this will be Symbol.iterator; in older browsers it will be a string, but is still useful with [can-util/js/each/each].
+	 */
+	iterator: (typeof Symbol === "function" && Symbol.iterator) || "@@iterator",
+	/**
 	 * @property {Map} can-util/js/types/types.DefaultMap DefaultMap
 	 *
 	 * @option {Map}


### PR DESCRIPTION
This adds support for iterables such as Maps to can-util/js/each/each.
Also adds a `types.iterator` property that can be used by iterables
types to make themselves usable by can-util/js/each/each. This mirrors
the JavaScript iterables API, and uses Symbol.iterator where available,
so anything implementing this API will be usable with for/of.

Closes #44
