### PR TITLE
Implements get/set for option[selected]

### DIFF
--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -205,6 +205,9 @@ test("'selected' is bindable on an <option>", function(){
 
 	option2.selected = true;
 	canEvent.trigger.call(select, "change");
+
+	equal(domAttr.get(option1, "selected"), false, "option1 is not selected");
+	equal(domAttr.get(option2, "selected"), true, "option2 is selected");
 });
 
 test('get, set, and addEventListener on focused', function(){

--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -109,6 +109,12 @@ var isSVG = function(el){
 				}
 			},
 			selected: {
+				get: function(){
+					return this.selected;
+				},
+				set: function(val){
+					return this.selected = !!val;
+				},
 				addEventListener: function(eventName, handler, aEL){
 					var option = this;
 					var select = this.parentNode;


### PR DESCRIPTION
This implements a get and set for the special `selected` attr. This is
so that we look at the property rather than the attribute.
