### PR TITLE
Makes attr.set CHECKED work with the boolean condition

### DIFF
--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -308,7 +308,7 @@ test("get, set on 'value'", function(){
 	equal(domAttr.get(input, "value"), "", "value is an empty string");
 });
 
-test("gets the checkedness of a checkbox", function(){
+test("get/sets the checkedness of a checkbox", function(){
 	var input = document.createElement("input");
 	input.type = "checkbox";
 
@@ -316,4 +316,7 @@ test("gets the checkedness of a checkbox", function(){
 
 	domAttr.set(input, "checked", true);
 	equal(domAttr.get(input, "checked"), true, "now it is true");
+
+	domAttr.set(input, "checked", false);
+	equal(domAttr.get(input, "checked"), false, "now it is false");
 });

--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -39,7 +39,7 @@ var isSVG = function(el){
 		return {
 			isBoolean: true,
 			set: function(value){
-				this[prop] = !!value;
+				this[prop] = value !== false;
 			},
 			remove: function(){
 				this[prop] = false;
@@ -52,12 +52,13 @@ var isSVG = function(el){
 				get: function(){
 					return this.checked;
 				},
-				set: function(){
-					this.checked = true;
-					if(this.type === "radio") {
+				set: function(val){
+					var notFalse = val !== false;
+					this.checked = notFalse;
+					if(notFalse && this.type === "radio") {
 						this.defaultChecked = true;
 					}
-					return true;
+					return val;
 				}
 			},
 			"class": {


### PR DESCRIPTION
This makes sure that boolean attributes work, so that we can do stuff
like:

``` js
attr.set(input, "checked");
```

Which will set it to true. You can still explicitly set it to false
with:

``` js
attr.set(input, "checked", false);
```

So the change is to make anything that's not `false` be truthy.
