### PR TITLE
Implement addEventListener for `focused` special

### DIFF
--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -223,7 +223,7 @@ test('get, set, and addEventListener on focused', function(){
 		focusedCount++;
 	});
 
-	equal( domAttr.get(input,"focused"), false, "get not focused" );
+	equal( domAttr.get(input, "focused"), false, "get not focused" );
 
 	domAttr.set(input, "focused", true);
 	equal(focusedCount, 1, "focused event");

--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -1,6 +1,7 @@
 var canEvent = require("can-event");
 var domAttr = require('can-util/dom/attr/attr');
 var domEvents = require('can-util/dom/events/events');
+var domDispatch = require("../dispatch/dispatch");
 var MUTATION_OBSERVER = require('can-util/dom/mutation-observer/mutation-observer');
 
 
@@ -226,10 +227,16 @@ test('get, set, and addEventListener on focused', function(){
 	equal( domAttr.get(input, "focused"), false, "get not focused" );
 
 	domAttr.set(input, "focused", true);
+	if(!document.hasFocus()) {
+		domDispatch.call(input, "focus");
+	}
 	equal(focusedCount, 1, "focused event");
 	equal( domAttr.get(input,"focused"), true, "get focused" );
 
 	domAttr.set(input, "focused", false);
+	if(!document.hasFocus()) {
+		domDispatch.call(input, "blur");
+	}
 	equal(focusedCount, 2, "focused event");
 	equal( domAttr.get(input,"focused"), false, "get not focused after blur" );
 });

--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -218,6 +218,7 @@ test('get, set, and addEventListener on focused', function(){
 
 	var focusedCount = 0;
 	// fired on blur and focus events
+	ok(domAttr.special.focused.addEventListener, "addEventListener implemented");
 	domEvents.addEventListener.call(input, "focused", function(){
 		focusedCount++;
 	});

--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -46,12 +46,6 @@ var isSVG = function(el){
 			}
 		};
 	},
-	defaultAddEventListener = function(eventName, handler, aEL){
-		aEL.call(this, eventName, handler);
-		return function(rEL){
-			rEL.call(this, eventName, handler);
-		};
-	},
 	attr = {
 		special: {
 			checked: {
@@ -95,14 +89,23 @@ var isSVG = function(el){
 					if(cur !== val) {
 						if(val) {
 							this.focus();
+							domDispatch.call(this, "focus");
 						} else {
 							this.blur();
+							domDispatch.call(this, "blur");
 						}
-						domDispatch.call(this, "focused");
+						//
 					}
 					return !!val;
 				},
-				addEventListener: defaultAddEventListener,
+				addEventListener: function(eventName, handler, aEL){
+					aEL.call(this, "focus", handler);
+					aEL.call(this, "blur", handler);
+					return function(rEL){
+						rEL.call(this, "focus", handler);
+						rEL.call(this, "blur", handler);
+					};
+				},
 				test: function(){
 					return this.nodeName === "INPUT";
 				}

--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -46,6 +46,12 @@ var isSVG = function(el){
 			}
 		};
 	},
+	defaultAddEventListener = function(eventName, handler, aEL){
+		aEL.call(this, eventName, handler);
+		return function(rEL){
+			rEL.call(this, eventName, handler);
+		};
+	},
 	attr = {
 		special: {
 			checked: {
@@ -96,6 +102,7 @@ var isSVG = function(el){
 					}
 					return !!val;
 				},
+				addEventListener: defaultAddEventListener,
 				test: function(){
 					return this.nodeName === "INPUT";
 				}

--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -89,12 +89,9 @@ var isSVG = function(el){
 					if(cur !== val) {
 						if(val) {
 							this.focus();
-							domDispatch.call(this, "focus");
 						} else {
 							this.blur();
-							domDispatch.call(this, "blur");
 						}
-						//
 					}
 					return !!val;
 				},


### PR DESCRIPTION
This implements addEventListener for the `focused` special. All this
does is call the parent addEventListener and eventually a real DOM event
is going to be created.

This is necessary because can-stache-bindings will only bind to special
events if there is an `addEventListener` defined.
