### PR TITLE
attr.checked - Fallback to setAttribute

### DIFF
--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -337,3 +337,18 @@ test("get/sets the checkedness of a checkbox", function(){
 	domAttr.set(input, "checked", "");
 	equal(domAttr.get(input, "checked"), true, "now it is true");
 });
+
+test("For inputs checked is set as an attribute", function(){
+	var input = document.createElement("input");
+	input.type = "checkbox";
+
+	domAttr.set(input, "checked", "");
+	equal(input.checked, true, "checked is true");
+	equal(input.getAttribute("checked"), undefined, "no checked attr");
+
+	var customEl = document.createElement("custom-element");
+
+	domAttr.set(customEl, "checked", "");
+	ok(customEl.hasAttribute("checked"), "has checked attr");
+	equal(customEl.getAttribute("checked"), "", "attr is an empty string");
+});

--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -13,8 +13,6 @@ var each = require("../../js/each/each");
 
 require("../events/attributes/attributes");
 
-// Acts as a polyfill for setImmediate which only works in IE 10+. Needed to make
-// the triggering of `attributes` event async.
 var isSVG = function(el){
 		return el.namespaceURI === "http://www.w3.org/2000/svg";
 	},
@@ -53,11 +51,16 @@ var isSVG = function(el){
 					return this.checked;
 				},
 				set: function(val){
-					var notFalse = !!val || val === undefined || val === "";
-					this.checked = notFalse;
-					if(notFalse && this.type === "radio") {
-						this.defaultChecked = true;
+					if(this.nodeName === "INPUT") {
+						var notFalse = !!val || val === undefined || val === "";
+						this.checked = notFalse;
+						if(notFalse && this.type === "radio") {
+							this.defaultChecked = true;
+						}
+					} else {
+						this.setAttribute("checked", val);
 					}
+
 					return val;
 				}
 			},


### PR DESCRIPTION
This makes it so that we fallback to setAttribute on the `checked`
property when setting it on a non-input.

Closes #70 
