### PR TITLE
Setup MutationObserver in attr.special.values

### DIFF
--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -360,3 +360,53 @@ test("attr.special.value, fallback to the attribute", function(){
 
 	equal(domAttr.get(customEl, "value"), "foo", "value is foo");
 });
+
+test("Setting a select's value updates child's selectedness", function(){
+	var select = document.createElement("select");
+	var option1 = document.createElement("option");
+	option1.value = "one";
+	option1.selected = true;
+	var option2 = document.createElement("option");
+	option2.value = "two";
+
+	select.appendChild(option1);
+	select.appendChild(option2);
+
+	equal(domAttr.get(select, "value"), "one", "initial value");
+	
+	domAttr.set(select, "value", "two");
+	equal(option1.selected, false, "not selected");
+	equal(option2.selected, true, "now it is selected");
+});
+
+test("Multiselect values is updated on any children added/removed", function(){
+	var select = document.createElement("select");
+	select.multiple = true;
+
+	var option1 = document.createElement("option");
+	option1.value = "one";
+
+	var option2 = document.createElement("option");
+	option2.value = "two";
+
+	var option3 = document.createElement("option");
+	option3.value = "three";
+	option3.selected = true;
+
+	select.appendChild(option1);
+	select.appendChild(option2);
+	select.appendChild(option3);
+
+	domAttr.set(select, "values", ["one", "three"]);
+	deepEqual(domAttr.get(select, "values"), ["one", "three"], "initial value is right");
+
+	domEvents.addEventListener.call(select, "values", function(){
+		deepEqual(domAttr.get(select, "values"), ["three"], "new val is right");
+
+		start();
+	});
+
+	select.removeChild(option1);
+
+	stop();
+});

--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -45,6 +45,25 @@ var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true},
 			}
 		};
 	},
+	setupMO = function(el, callback){
+		var hasSetupMO = setData.get.call(el, "attrMOSetup");
+		if(!hasSetupMO) {
+			setData.set.call(el, "attrMOSetup", true);
+			var onMutation = function(){
+				callback.call(el);
+			};
+			var MO = MUTATION_OBSERVER();
+			if(MO) {
+				var observer = new MO(onMutation);
+				observer.observe(el, {
+					childList: true,
+					subtree: true
+				});
+			} else {
+				setData.set.call(el, "canBindingCallback", {onMutation: onMutation});
+			}
+		}
+	},
 	attr = {
 		special: {
 			checked: {
@@ -228,6 +247,7 @@ var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true},
 						}
 						child = child.nextSibling;
 					}
+					setData.set.call(this, "valuesLastVal", values);
 					return values;
 				},
 				set: function(values){
@@ -239,6 +259,14 @@ var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true},
 						}
 						child = child.nextSibling;
 					}
+
+					setData.set.call(this, "valuesLastVal", values);
+					setupMO(this, function(){
+						var lastVal = setData.get.call(this, "valuesLastVal");
+						attr.set(this, "values", lastVal);
+						domDispatch.call(this, "values");
+					});
+
 					return values;
 				},
 				addEventListener: function(eventName, handler, aEL){


### PR DESCRIPTION
This MutationObserver is used so that we can reset the multiselects
values any time there is a mutation in its child options. We then will
fire a `values` event which should update the values.

Part of #67
