### PR TITLE
When setting child options, compare string value

### DIFF
--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -473,3 +473,17 @@ test("Boolean attrs that don't support a prop sets the attribute", function(){
 
 	equal(domAttr.get(div, "disabled"), "", "empty string");
 });
+
+test("Setting a non-string value on a select correctly selects the child", function(){
+	var select = document.createElement("select");
+	var option1 = document.createElement("option");
+	option1.value = "1";
+	var option2 = document.createElement("option");
+	option2.value = "2";
+
+	select.appendChild(option1);
+	select.appendChild(option2);
+
+	domAttr.set(select, "value", 2);
+	equal(option2.selected, true, "second one is selected");
+});

--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -265,7 +265,7 @@ var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true},
 					}
 					if(nodeName === "select") {
 						setData.set.call(this, "attrValueLastVal", value);
-						setChildOptions(this, value);
+						setChildOptions(this, this.value);
 						setupMO(this, function(){
 							var value = setData.get.call(this, "attrValueLastVal");
 							attr.set(this, "value", value);


### PR DESCRIPTION
When setting the child options on a `<select>` when its value is set,
         compare the string value of `select.value` to the child's
         `option.value` rather than what was provided through
`domAttr.set()`.
