### PR TITLE
Documents the focused and values special properties

### DIFF
--- a/dom/attr/attr-special.focused.md
+++ b/dom/attr/attr-special.focused.md
@@ -1,0 +1,44 @@
+@property {Boolean} can-util/dom/attr/attr.special.focused focused
+@parent can-util/dom/attr/attr.special
+
+Signifies if an element, usually an `<input>` is the focused element on the page.
+
+```js
+domAttr.get(input, "focused"); // -> false
+
+domAttr.set(input, "focused", true);
+domAttr.get(input, "focused"); // -> true
+```
+
+@body
+
+## One-way binding to set focus
+
+Use `focused` in event bindings to have a way to set focus to an input. In this example we are one-way binding to `focused` to a function that will recompute:
+
+```handlebars
+<input type="text" {$focused}="isEditing()" />
+
+<button></button>
+```
+
+```js
+var ViewModel = DefineMap.extend({
+	editing: {
+		value: false
+	},
+	isEditing: function(){
+		return this.editing;
+	}
+});
+
+...
+```
+
+In this example whenever the `editing` property changes to `true`, `isEditing` will be reevaluated to `true` when will set focus on the input. You can imagine there might be some other use, such as a button, that triggers the editing status to change.
+
+## Two-way binding to focused
+
+Another scenario is that you would like to know when an element is focused, perhaps to show a message (such as a tooltip) somewhere else in the DOM. The example below two-way binds to a boolean property on the ViewModel. When focus is set, the property is updated.
+
+@demo demos/can-util/input-focused.html

--- a/dom/attr/attr-special.md
+++ b/dom/attr/attr-special.md
@@ -16,3 +16,8 @@ attr.special.foo = {
 	}
 };
 ```
+
+CanJS comes with a couple of special properties that can be used in bindings:
+
+* [can-util/dom/attr/attr.special.values]
+* [can-util/dom/attr/attr.special.focused]

--- a/dom/attr/attr.special.values.md
+++ b/dom/attr/attr.special.values.md
@@ -1,0 +1,18 @@
+@property {Boolean} can-util/dom/attr/attr.special.values values
+@parent can-util/dom/attr/attr.special
+
+A special property that represents the selected values in a `<select>` element, usually a `<select multiple>`. The special property is needed because the DOM's native `value` property on a multiple select only gives you one of the selected options' values.
+
+@body
+
+Binding to `values` in your [can-stache] template is useful to get a list of the selected values:
+
+```handlebars
+<select multiple {($values)}="colors">
+	<option value="red">Red</option>
+	<option value="green">Green</option>
+	<option value="blue">Blue</option>
+</select>
+```
+
+This will two-way bind to a "colors" property in the ViewModel.


### PR DESCRIPTION
This adds documentation for the `focused` and `values` special
properties. Longer explanations are in can-stache-converters.
