### PR TITLE
Special case `null` when setting a select's value

### DIFF
--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -487,3 +487,20 @@ test("Setting a non-string value on a select correctly selects the child", funct
 	domAttr.set(select, "value", 2);
 	equal(option2.selected, true, "second one is selected");
 });
+
+test("Setting null doesn't select the default value on a select", function(){
+	var select = document.createElement("select");
+	var option1 = document.createElement("option");
+	option1.value = '';
+	var option2 = document.createElement("option");
+	option2.value = "two";
+
+	select.appendChild(option1);
+	select.appendChild(option2);
+
+	// This is really stupid
+	domAttr.set(select, "value", null);
+	equal(option1.selected, false, "option1 not selected");
+	equal(option2.selected, false, "option2 not selected");
+	equal(select.selectedIndex, -1, "no selected index, wha-wha");
+});

--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -265,7 +265,8 @@ var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true},
 					}
 					if(nodeName === "select") {
 						setData.set.call(this, "attrValueLastVal", value);
-						setChildOptions(this, this.value);
+						//If it's null then special case
+						setChildOptions(this, value === null ? value : this.value);
 						setupMO(this, function(){
 							var value = setData.get.call(this, "attrValueLastVal");
 							attr.set(this, "value", value);


### PR DESCRIPTION
For some reason this behavior is desired:

```
<select {($value)}="foo">
    <option value="">Not selected</option>
</select>
```

Setting foo to `null` sets nothing.
