### PR TITLE
attr.special.focused uses types.afterEvents

### DIFF
--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -3,6 +3,7 @@ var domAttr = require('can-util/dom/attr/attr');
 var domEvents = require('can-util/dom/events/events');
 var domDispatch = require("../dispatch/dispatch");
 var MUTATION_OBSERVER = require('can-util/dom/mutation-observer/mutation-observer');
+var types = require("../../js/types/types");
 
 
 QUnit = require('steal-qunit');
@@ -512,4 +513,27 @@ test("setting .value on an input to undefined or null makes value empty (#83)", 
 	QUnit.equal(input.value, "", "null");
 	domAttr.set(input, "value", undefined);
 	QUnit.equal(input.value, "", "undefined");
+});
+
+test("attr.special.focused calls after previous events", function(){
+	var oldAfter = types.afterEvents;
+	types.afterEvents = function(fn){
+		setTimeout(fn, 5);
+	};
+
+	var input = document.createElement("input");
+	input.type = "text";
+	var ta = document.getElementById("qunit-fixture");
+	ta.appendChild(input);
+
+	stop();
+
+	domAttr.set(input, "focused", true);
+	setTimeout(function(){
+		equal(domAttr.get(input, "focused"), true, "it is now focused");
+		types.afterEvents = oldAfter;
+		start();
+	}, 10);
+
+	equal(domAttr.get(input, "focused"), false, "not focused yet");
 });

--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -10,6 +10,7 @@ var domEvents = require("../events/events");
 var domDispatch = require("../dispatch/dispatch");
 var MUTATION_OBSERVER = require("../mutation-observer/mutation-observer");
 var each = require("../../js/each/each");
+var types = require("../../js/types/types");
 
 require("../events/attributes/attributes");
 
@@ -143,11 +144,14 @@ var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true},
 				set: function(val){
 					var cur = attr.get(this, "focused");
 					if(cur !== val) {
-						if(val) {
-							this.focus();
-						} else {
-							this.blur();
-						}
+						var element = this;
+						types.afterEvents(function(){
+							if(val) {
+								element.focus();
+							} else {
+								element.blur();
+							}
+						});
 					}
 					return !!val;
 				},

--- a/js/types/types.js
+++ b/js/types/types.js
@@ -31,6 +31,14 @@ var isPromise = require('../is-promise/is-promise');
 
 var types = {
 	/**
+	 * @function can-util/js/types/types.afterEvents afterEvents
+	 * @signature `types.afterEvents(fn)`
+	 *   A function to be run after the end of the current event batch.
+	 */
+	afterEvents: function(fn){
+		fn();
+	},
+	/**
 	 * @function can-util/js/types/types.isMapLike isMapLike
 	 * @signature `types.isMapLike(obj)`
 	 *   Returns true if `obj` is an observable key-value pair type object.


### PR DESCRIPTION
This makes it so that the special `focused` property uses
`types.afterEvents` when will be can-events/batch/batch's
afterPreviousEvents.

Part of #80
