### PR TITLE
attr.special.focused using the batch queue

### DIFF
--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -516,9 +516,11 @@ test("setting .value on an input to undefined or null makes value empty (#83)", 
 });
 
 test("attr.special.focused calls after previous events", function(){
-	var oldAfter = types.afterEvents;
-	types.afterEvents = function(fn){
-		setTimeout(fn, 5);
+	var oldQueue = types.queueTask;
+	types.queueTask = function(task){
+		setTimeout(function(){
+			task[0].apply(task[1], task[2]);
+		}, 5);
 	};
 
 	var input = document.createElement("input");
@@ -531,7 +533,7 @@ test("attr.special.focused calls after previous events", function(){
 	domAttr.set(input, "focused", true);
 	setTimeout(function(){
 		equal(domAttr.get(input, "focused"), true, "it is now focused");
-		types.afterEvents = oldAfter;
+		types.queueTask = oldQueue;
 		start();
 	}, 10);
 

--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -145,13 +145,13 @@ var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true},
 					var cur = attr.get(this, "focused");
 					if(cur !== val) {
 						var element = this;
-						types.afterEvents(function(){
+						types.queueTask([function(){
 							if(val) {
 								element.focus();
 							} else {
 								element.blur();
 							}
-						});
+						}, this, []]);
 					}
 					return !!val;
 				},

--- a/js/types/types.js
+++ b/js/types/types.js
@@ -31,14 +31,6 @@ var isPromise = require('../is-promise/is-promise');
 
 var types = {
 	/**
-	 * @function can-util/js/types/types.afterEvents afterEvents
-	 * @signature `types.afterEvents(fn)`
-	 *   A function to be run after the end of the current event batch.
-	 */
-	afterEvents: function(fn){
-		fn();
-	},
-	/**
 	 * @function can-util/js/types/types.isMapLike isMapLike
 	 * @signature `types.isMapLike(obj)`
 	 *   Returns true if `obj` is an observable key-value pair type object.
@@ -140,6 +132,16 @@ var types = {
 	 *   @param {Node} element Any object inheriting from the [Node interface](https://developer.mozilla.org/en-US/docs/Web/API/Node).
 	 *   @return {{}} A wrapped object.
 	 */
+	/**
+	 * @function can-util/js/types/types.queueTask queueTask
+	 * @signature `types.queueTask(task)`
+	 *   Run code that will be queued at the end of the current batch.
+	 *   @param {Array} task
+	 */
+	queueTask: function(task){
+		var args = task[2] || [];
+		task[0].apply(task[1], args);
+	},
 	wrapElement: function(element){
 		return element;
 	},

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "bit-docs": "0.0.7",
-    "can-event": "^3.0.0-pre.10",
+    "can-event": "^3.0.0-pre.13",
     "cssify": "^1.0.2",
     "done-serve": "^0.2.4",
     "donejs-cli": "^0.9.5",


### PR DESCRIPTION
This makes it so that attr.special.focused puts itself into
can-event/batch/batch's queue. Going into the queue puts it at the end
of the batch.

Closes #80 
