### PR TITLE
Makes the focused test work asynchronously.

### DIFF
--- a/dom/attr/test.html
+++ b/dom/attr/test.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html>
-<head> </head>
+<head>
+	<title>can-util/dom/attr/attr test</title>
+</head>
 <body>
 <div id="qunit-fixture"></div>
 <script src="../../node_modules/steal/steal.js"


### PR DESCRIPTION
IE10 (and maybe other versions) fires `focus` and `blur` events
asynchronously. This refactors the focused test to work asynchronously,
    which makes it work in all browsers. Closes #88
