### PR TITLE
Allow to abort XHR in IE9 as well

### DIFF
--- a/dom/ajax/ajax-test.js
+++ b/dom/ajax/ajax-test.js
@@ -20,7 +20,13 @@ QUnit.asyncTest("abort", function () {
 		url: __dirname+"/test-result.json"
 	});
 	promise.catch(function(xhr) {
-		QUnit.equal(xhr.readyState, 0, "aborts the promise");
+		if(xhr instanceof Error) {
+			// IE9 - see http://stackoverflow.com/questions/7287706/ie-9-javascript-error-c00c023f
+			QUnit.equal(xhr.message, 'Could not complete the operation due to error c00c023f.');
+		} else {
+			QUnit.equal(xhr.readyState, 0, "aborts the promise");
+		}
+		
 		start();
 	});
 	promise.abort();

--- a/dom/ajax/ajax.js
+++ b/dom/ajax/ajax.js
@@ -94,30 +94,34 @@ module.exports = function (o) {
 		}, o.timeout);
 	}
 	xhr.onreadystatechange = function () {
-		if (xhr.readyState === 4) {
-			if (timer) {
-				clearTimeout(timer);
-			}
-			if (xhr.status < 300) {
-				if (o.success) {
-					o.success($._xhrResp(xhr));
+		try {
+			if (xhr.readyState === 4) {
+				if (timer) {
+					clearTimeout(timer);
+				}
+				if (xhr.status < 300) {
+					if (o.success) {
+						o.success($._xhrResp(xhr));
+					}
+				}
+				else if (o.error) {
+					o.error(xhr, xhr.status, xhr.statusText);
+				}
+				if (o.complete) {
+					o.complete(xhr, xhr.statusText);
+				}
+
+				if( xhr.status === 200 ) {
+					deferred.resolve( JSON.parse( xhr.responseText ) );
+				} else {
+					deferred.reject( xhr );
 				}
 			}
-			else if (o.error) {
-				o.error(xhr, xhr.status, xhr.statusText);
+			else if (o.progress) {
+				o.progress(++n);
 			}
-			if (o.complete) {
-				o.complete(xhr, xhr.statusText);
-			}
-
-			if( xhr.status === 200 ) {
-				deferred.resolve( JSON.parse( xhr.responseText ) );
-			} else {
-				deferred.reject( xhr );
-			}
-		}
-		else if (o.progress) {
-			o.progress(++n);
+		} catch(e) {
+			deferred.reject(e);
 		}
 	};
 	var url = o.url, data = null;


### PR DESCRIPTION
For IE 9 the `onreadystatechange` logic needs to be wrapped in a `try/catch` because it won't let you read any properties from an aborted XHR. See http://stackoverflow.com/questions/7287706/ie-9-javascript-error-c00c023f
