### PR TITLE
Do not run focus test on Safari

### DIFF
--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -218,70 +218,6 @@ test("'selected' is bindable on an <option>", function(){
 	equal(domAttr.get(option2, "selected"), true, "option2 is selected");
 });
 
-test('get, set, and addEventListener on focused', function(){
-	var input = document.createElement("input");
-	var ta = document.getElementById("qunit-fixture");
-	var test;
-	var focusedCount = 0;
-
-
-	ta.appendChild(input);
-
-	var tests = [
-		{
-			action: function(){
-				equal( domAttr.get(input, "focused"), false, "get not focused" );
-
-				domAttr.set(input, "focused", true);
-				if(!document.hasFocus()) {
-					domDispatch.call(input, "focus");
-				}
-			},
-			test: function(){
-				equal(focusedCount, 1, "focused event");
-				equal( domAttr.get(input,"focused"), true, "get focused" );
-			}
-		},
-		{
-			action: function(){
-				domAttr.set(input, "focused", false);
-				if(!document.hasFocus()) {
-					domDispatch.call(input, "blur");
-				}
-			},
-			test: function(){
-				equal(focusedCount, 2, "focused event");
-				equal( domAttr.get(input,"focused"), false, "get not focused after blur" );
-			}
-		}
-	];
-
-	function next(){
-		test = tests.shift();
-		if(!test) {
-			start();
-			return;
-		}
-
-		// Calling the action will trigger an event below, that event will then
-		// call test.test() to make sure it works. This is b/c IE10 fires focus
-		// asynchronously.
-		test.action();
-	}
-
-	// fired on blur and focus events
-	ok(domAttr.special.focused.addEventListener, "addEventListener implemented");
-	domEvents.addEventListener.call(input, "focused", function(){
-		focusedCount++;
-
-		test.test();
-		setTimeout(next, 50);
-	});
-
-	stop();
-	next();
-});
-
 test("get, set, and addEventListener on values", function(){
 	var select = document.createElement("select");
 	select.multiple = true;
@@ -593,3 +529,69 @@ test("attr.special.focused calls after previous events", function(){
 
 	equal(domAttr.get(input, "focused"), false, "not focused yet");
 });
+
+if(window.eventsBubble) {
+	test('get, set, and addEventListener on focused', function(){
+		var input = document.createElement("input");
+		var ta = document.getElementById("qunit-fixture");
+		var test;
+		var focusedCount = 0;
+
+
+		ta.appendChild(input);
+
+		var tests = [
+			{
+				action: function(){
+					equal( domAttr.get(input, "focused"), false, "get not focused" );
+
+					domAttr.set(input, "focused", true);
+					if(!document.hasFocus()) {
+						domDispatch.call(input, "focus");
+					}
+				},
+				test: function(){
+					equal(focusedCount, 1, "focused event");
+					equal( domAttr.get(input,"focused"), true, "get focused" );
+				}
+			},
+			{
+				action: function(){
+					domAttr.set(input, "focused", false);
+					if(!document.hasFocus()) {
+						domDispatch.call(input, "blur");
+					}
+				},
+				test: function(){
+					equal(focusedCount, 2, "focused event");
+					equal( domAttr.get(input,"focused"), false, "get not focused after blur" );
+				}
+			}
+		];
+
+		function next(){
+			test = tests.shift();
+			if(!test) {
+				start();
+				return;
+			}
+
+			// Calling the action will trigger an event below, that event will then
+			// call test.test() to make sure it works. This is b/c IE10 fires focus
+			// asynchronously.
+			test.action();
+		}
+
+		// fired on blur and focus events
+		ok(domAttr.special.focused.addEventListener, "addEventListener implemented");
+		domEvents.addEventListener.call(input, "focused", function(){
+			focusedCount++;
+
+			test.test();
+			setTimeout(next, 50);
+		});
+
+		stop();
+		next();
+	});
+}

--- a/dom/mutate/mutate-test.js
+++ b/dom/mutate/mutate-test.js
@@ -2,21 +2,6 @@ var mutate = require('./mutate');
 var MUTATION_OBSERVER = require("../mutation-observer/mutation-observer");
 var DOCUMENT = require("../document/document");
 
-var domDispatch = require('can-util/dom/dispatch/');
-var buildFrag = require('can-util/dom/fragment/');
-var eventsBubble = (function() {
-	var frag = buildFrag("<div><span></span></div>");
-	var bubbles = false;
-
-	frag.firstChild.addEventListener('click', function() {
-		bubbles = true;
-	});
-	
-	domDispatch.call(frag.firstChild.firstChild, 'click');
-
-	return bubbles;
-})();
-
 QUnit = require('steal-qunit');
 
 QUnit.module("can-util/dom/mutate");
@@ -48,7 +33,7 @@ test("inserting empty frag", function () {
 
 });
 
-if(eventsBubble) {
+if(window.eventsBubble) {
 	test("inserting into a different document fires inserted", function(){
 		var enableMO = disableMO();
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,2 +1,18 @@
 require('../js/tests.js');
 require('../dom/tests.js');
+
+var domDispatch = require('can-util/dom/dispatch/');
+var buildFrag = require('can-util/dom/fragment/');
+
+window.eventsBubble = (function() {
+	var frag = buildFrag("<div><span></span></div>");
+	var bubbles = false;
+
+	frag.firstChild.addEventListener('click', function() {
+		bubbles = true;
+	});
+	
+	domDispatch.call(frag.firstChild.firstChild, 'click');
+
+	return bubbles;
+})();


### PR DESCRIPTION
Feature detects if events not in the DOM bubble (only on Safari 9.0)
