### PR TITLE
fixing issue with removing two `attributes` event listeners

### DIFF
--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -530,6 +530,21 @@ test("attr.special.focused calls after previous events", function(){
 	equal(domAttr.get(input, "focused"), false, "not focused yet");
 });
 
+test("handles removing multiple event handlers", function () {
+	var handler1 = function() {};
+	var handler2 = function() {};
+
+	var div = document.createElement('div');
+
+	domEvents.addEventListener.call(div, "attributes", handler1, false);
+	domEvents.addEventListener.call(div, "attributes", handler2, false);
+
+	domEvents.removeEventListener.call(div, "attributes", handler1);
+	domEvents.removeEventListener.call(div, "attributes", handler2);
+
+	ok(true, 'should not throw');
+});
+
 if(window.eventsBubble) {
 	test('get, set, and addEventListener on focused', function(){
 		var input = document.createElement("input");

--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -545,6 +545,24 @@ test("handles removing multiple event handlers", function () {
 	ok(true, 'should not throw');
 });
 
+test("handles removing multiple event handlers without MUTATION_OBSERVER", function () {
+	var MO = MUTATION_OBSERVER();
+	MUTATION_OBSERVER(null);
+	var handler1 = function() {};
+	var handler2 = function() {};
+
+	var div = document.createElement('div');
+
+	domEvents.addEventListener.call(div, "attributes", handler1, false);
+	domEvents.addEventListener.call(div, "attributes", handler2, false);
+
+	domEvents.removeEventListener.call(div, "attributes", handler1);
+	domEvents.removeEventListener.call(div, "attributes", handler2);
+
+	ok(true, 'should not throw');
+	MUTATION_OBSERVER(MO);
+});
+
 if(window.eventsBubble) {
 	test('get, set, and addEventListener on focused', function(){
 		var input = document.createElement("input");

--- a/dom/data/data.js
+++ b/dom/data/data.js
@@ -69,7 +69,9 @@ module.exports = {
 	 */
 	clean: function(prop) {
 		var id = this[expando];
-		delete data[id][prop];
+		if (data[id] && data[id][prop]) {
+			delete data[id][prop];
+		}
 		if(isEmptyObject(data[id])) {
 			delete data[id];
 		}

--- a/dom/events/attributes/attributes.js
+++ b/dom/events/attributes/attributes.js
@@ -57,10 +57,15 @@ events.addEventListener = function(eventName){
 events.removeEventListener = function(eventName){
 	if(eventName === "attributes") {
 		var MutationObserver = getMutationObserver();
+		var observer;
 
 		if(isOfGlobalDocument(this) && MutationObserver) {
-			domData.get.call(this, "canAttributesObserver").disconnect();
-			domData.clean.call(this, "canAttributesObserver");
+			observer = domData.get.call(this, "canAttributesObserver");
+
+			if (observer && observer.disconnect) {
+				observer.disconnect();
+				domData.clean.call(this, "canAttributesObserver");
+			}
 		} else {
 			domData.clean.call(this, "canHasAttributesBindings");
 		}


### PR DESCRIPTION
Closes https://github.com/canjs/can-util/issues/115.
