### PR TITLE
When the select change event fires, update change selectedness

### DIFF
--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -203,7 +203,9 @@ test("attr.special addEventListener allows custom binding", function(){
 test("'selected' is bindable on an <option>", function(){
 	var select = document.createElement("select");
 	var option1 = document.createElement("option");
+	option1.value = "one";
 	var option2 = document.createElement("option");
+	option2.value = "two";
 	select.appendChild(option1);
 	select.appendChild(option2);
 
@@ -628,3 +630,23 @@ if(window.eventsBubble) {
 		next();
 	});
 }
+
+test("Binding to selected updates the selectedness of options", function(){
+	var select = document.createElement("select");
+	var option1 = document.createElement("option");
+	option1.selected = true;
+	option1.value = "one";
+	select.appendChild(option1);
+
+	var option2 = document.createElement("option");
+	option2.value = "two";
+	select.appendChild(option2);
+
+	domEvents.addEventListener.call(option1, "selected");
+
+	option2.selected = true;
+	domDispatch.call(select, "change");
+
+	equal(option2.selected, true);
+	equal(option1.selected, false);
+});

--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -632,9 +632,10 @@ if(window.eventsBubble) {
 }
 
 test("Binding to selected updates the selectedness of options", function(){
+	expect(3);
 	var select = document.createElement("select");
 	var option1 = document.createElement("option");
-	option1.selected = true;
+	option1.selected = false;
 	option1.value = "one";
 	select.appendChild(option1);
 
@@ -642,7 +643,11 @@ test("Binding to selected updates the selectedness of options", function(){
 	option2.value = "two";
 	select.appendChild(option2);
 
-	domEvents.addEventListener.call(option1, "selected");
+	domEvents.addEventListener.call(option1, "selected", function(){
+		ok(true, "this was called");
+	});
+
+	domAttr.set(option1, "selected", true);
 
 	option2.selected = true;
 	domDispatch.call(select, "change");

--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -96,6 +96,23 @@ var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true},
 			}
 		}
 	},
+	// Create a handler, only once, that will set the child options any time
+	// the select's value changes.
+	setChildOptionsOnChange = function(select, aEL){
+		var handler = setData.get.call(select, "attrSetChildOptions");
+		if(handler) {
+			return Function.prototype;
+		}
+		handler = function(){
+			setChildOptions(select, select.value);
+		};
+		setData.set.call(select, "attrSetChildOptions", handler);
+		aEL.call(select, "change", handler);
+		return function(rEL){
+			setData.clean.call(select, "attrSetChildOptions");
+			rEL.call(select, "change", handler);
+		};
+	},
 	attr = {
 		special: {
 			checked: {
@@ -224,10 +241,13 @@ var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true},
 							domDispatch.call(option, eventName);
 						}
 					};
+
+					var removeChangeHandler = setChildOptionsOnChange(select, aEL);
 					domEvents.addEventListener.call(select, "change", localHandler);
 					aEL.call(option, eventName, handler);
 
 					return function(rEL){
+						removeChangeHandler(rEL);
 						domEvents.removeEventListener.call(select, "change", localHandler);
 						rEL.call(option, eventName, handler);
 					};

--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -227,7 +227,9 @@ var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true},
 					return this.selected;
 				},
 				set: function(val){
-					return this.selected = !!val;
+					val = !!val;
+					setData.set.call(this, "lastSetValue", val);
+					return this.selected = val;
 				},
 				addEventListener: function(eventName, handler, aEL){
 					var option = this;
@@ -235,6 +237,7 @@ var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true},
 					var lastVal = option.selected;
 					var localHandler = function(changeEvent){
 						var curVal = option.selected;
+						lastVal = setData.get.call(option, "lastSetValue") || lastVal;
 						if(curVal !== lastVal) {
 							lastVal = curVal;
 


### PR DESCRIPTION
In IE9 and IE10 an `option` element's selected property is not updated
to reflect the parent select's value. So we will bind to the select
element's change event once and set it's child options any time the
change event fires.

Closes #120
