### PR TITLE
Increasing test timeout

### DIFF
--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -674,6 +674,6 @@ test("Select's value is preserved when inserted into the document", function(){
 	setTimeout(function(){
 		equal(select.selectedIndex, -1, "still is -1");
 		start();
-	}, 1);
+	}, 50);
 
 });


### PR DESCRIPTION
This test fails in IE10 when running in the canjs/canjs test suite.
Increasing the timeout to account for any slowdown because of all
of the other tests running.
