### PR TITLE
steal-remove wraps dev.warn statements

### DIFF
--- a/js/string/string.js
+++ b/js/string/string.js
@@ -87,7 +87,9 @@ var string = {
 	 * ```
 	 */
 	getObject: function (name, roots) {
+		//!steal-remove-start
 		canDev.warn('string.getObject is deprecated, please use get instead.');
+		//!steal-remove-end
 
 		roots = isArray(roots) ? roots : [roots || window];
 


### PR DESCRIPTION
Fixes canjs/can-util#136 for this repo.
