### PR TITLE
Making sure removed events are not fired on elements that are still in the DOM

### DIFF
--- a/dom/events/make-mutation-event/make-mutation-event.js
+++ b/dom/events/make-mutation-event/make-mutation-event.js
@@ -29,15 +29,21 @@ require("../../is-of-global-document/");
  */
 module.exports = function(specialEventName, mutationNodesProperty){
 	var originalAdd = events.addEventListener,
-		originalRemove = events.removeEventListener;
+		originalRemove = events.removeEventListener,
+		doDispatch = true;
 	var dispatchIfListening = function(mutatedNode, specialEventData, dispatched){
-
 		if(dispatched.has(mutatedNode)) {
 			return true;
 		}
 		dispatched.add(mutatedNode);
+		if(specialEventName === "removed") {
+			var documentElement = getDocument().documentElement;
+			if(documentElement.contains(mutatedNode)) {
+				doDispatch = false;
+			}
+		} 
 
-		if(specialEventData.nodeIdsRespondingToInsert.has(mutatedNode)) {
+		if(doDispatch && specialEventData.nodeIdsRespondingToInsert.has(mutatedNode)) {
 			domDispatch.call(mutatedNode, specialEventName, [], false);
 		}
 	};

--- a/dom/events/removed/removed-test.js
+++ b/dom/events/removed/removed-test.js
@@ -47,6 +47,23 @@ if(_MutationObserver) {
 		document.getElementById("qunit-fixture").appendChild(div);
 		document.getElementById("qunit-fixture").removeChild(div);
 	});
+
+	asyncTest("with mutation observer - move", function () {
+		var div = document.createElement("div");
+		var span = document.createElement("span");
+		var p = document.createElement("p");
+		div.appendChild(span);
+		div.appendChild(p);
+		domMutate.appendChild.call(document.getElementById("qunit-fixture"), div);
+		
+		domEvents.addEventListener.call(p, "removed", function(){
+			ok(false, "called removed");
+		});
+
+		start();
+		div.insertBefore(p, span);
+		ok(true);
+	});
 }
 
 asyncTest("basic insertion without mutation observer - removeChild", function(){


### PR DESCRIPTION
This prevents `removed` events from being dispatched when the mutated element is still in the DOM. 

This happens if you rearrange DOM elements (like sorting a list). 

Before the `removed` events were dispatched and would tear down all bindings for the element and its children.