### PR TITLE
Remove cssify as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "devDependencies": {
     "bit-docs": "0.0.7",
     "can-event": "^3.0.0-pre.13",
-    "cssify": "^1.0.2",
     "done-serve": "^0.2.4",
     "donejs-cli": "^0.9.5",
     "generator-donejs": "^0.9.0",


### PR DESCRIPTION
This removes cssify as a dependency which is not used by this project.