### PR TITLE
Add can-util/log/log

### DIFF
--- a/js/dev/dev.js
+++ b/js/dev/dev.js
@@ -1,14 +1,29 @@
 var canLog = require("../log/log");
 
+/**
+ * @module {{}} can-util/js/dev/dev dev
+ * @parent can-util/js
+ *
+ * Utilities for logging development-mode messages. Use this module for
+ * anything that should be shown to the user during development but isn't
+ * needed in production. In production these functions become noops.
+ */
 module.exports = {
 	warnTimeout: 5000,
 	logLevel: 0,
 	/**
+	 * @function can-util/js/dev/dev.warn warn
+	 * @parent can-util/js/dev/dev
+	 * @description
+	 *
 	 * Adds a warning message to the console.
+	 *
 	 * ```
 	 * dev.warn("something evil");
 	 * ```
-	 * @param {String} out the message
+	 *
+	 * @signature `dev.warn(msg)`
+	 * @param {String} msg The warning message.
 	 */
 	warn: function() {
 		//!steal-remove-start
@@ -16,11 +31,18 @@ module.exports = {
 		//!steal-remove-end
 	},
 	/**
+	 * @function can-util/js/dev/dev.log log
+	 * @parent can-util/js/dev/dev
+	 * @description
+	 *
 	 * Adds a message to the console.
+	 *
 	 * ```
 	 * dev.log("hi");
 	 * ```
-	 * @param {String} out the message
+	 *
+	 * @signature `dev.log(msg)`
+	 * @param {String} msg The message.
 	 */
 	log: function() {
 		//!steal-remove-start

--- a/js/dev/dev.js
+++ b/js/dev/dev.js
@@ -1,3 +1,5 @@
+var canLog = require("../log/log");
+
 module.exports = {
 	warnTimeout: 5000,
 	logLevel: 0,
@@ -8,19 +10,9 @@ module.exports = {
 	 * ```
 	 * @param {String} out the message
 	 */
-	warn: function (out) {
+	warn: function() {
 		//!steal-remove-start
-		var ll = this.logLevel;
-		if (ll < 2) {
-			Array.prototype.unshift.call(arguments, 'WARN:');
-			if (typeof console !== "undefined" && console.warn) {
-				this._logger("warn", Array.prototype.slice.call(arguments));
-			} else if (typeof console !== "undefined" && console.log) {
-				this._logger("log", Array.prototype.slice.call(arguments));
-			} else if (window && window.opera && window.opera.postError) {
-				window.opera.postError("steal.js WARNING: " + out);
-			}
-		}
+		canLog.warn.apply(this, arguments);
 		//!steal-remove-end
 	},
 	/**
@@ -30,26 +22,10 @@ module.exports = {
 	 * ```
 	 * @param {String} out the message
 	 */
-	log: function (out) {
+	log: function() {
 		//!steal-remove-start
-		var ll = this.logLevel;
-		if (ll < 1) {
-			if (typeof console !== "undefined" && console.log) {
-				Array.prototype.unshift.call(arguments, 'Info:');
-				this._logger("log", Array.prototype.slice.call(arguments));
-			} else if (window && window.opera && window.opera.postError) {
-				window.opera.postError("steal.js INFO: " + out);
-			}
-		}
+		canLog.log.apply(this, arguments);
 		//!steal-remove-end
 	},
-	_logger: function (type, arr) {
-		//!steal-remove-start
-		try {
-			console[type].apply(console, arr);
-		} catch(e) {
-			console[type](arr);
-		}
-		//!steal-remove-end
-	}
+	_logger: canLog._logger
 };

--- a/js/log/log-test.js
+++ b/js/log/log-test.js
@@ -1,0 +1,19 @@
+var QUnit = require("../../test/qunit");
+var canLog = require("./log");
+
+if(typeof console !== "undefined") {
+
+	QUnit.module("can-util/js/log");
+
+	QUnit.test("log.log works", function(){
+		QUnit.expect(2);
+		var log = console.log;
+		console.log = function(type, msg){
+			QUnit.equal(type, "Info:");
+			QUnit.equal(msg, "it worked");
+			console.log = log;
+		};
+
+		canLog.log("it worked");
+	});
+}

--- a/js/log/log-test.js
+++ b/js/log/log-test.js
@@ -9,11 +9,35 @@ if(typeof console !== "undefined") {
 		QUnit.expect(2);
 		var log = console.log;
 		console.log = function(type, msg){
-			QUnit.equal(type, "Info:");
+			QUnit.equal(type, "INFO:");
 			QUnit.equal(msg, "it worked");
 			console.log = log;
 		};
 
 		canLog.log("it worked");
+	});
+
+	QUnit.test("log.warn works", function(){
+		QUnit.expect(2);
+		var warn = console.warn;
+		console.warn = function(type, msg){
+			QUnit.equal(type, "WARN:");
+			QUnit.equal(msg, "it worked");
+			console.warn = warn;
+		};
+
+		canLog.warn("it worked");
+	});
+
+	QUnit.test("log.error works", function(){
+		QUnit.expect(2);
+		var error = console.error;
+		console.error = function(type, msg){
+			QUnit.equal(type, "ERROR:");
+			QUnit.equal(msg, "an error");
+			console.error = error;
+		};
+
+		canLog.error("an error");
 	});
 }

--- a/js/log/log.js
+++ b/js/log/log.js
@@ -2,13 +2,27 @@ exports.warnTimeout = 5000;
 exports.logLevel = 0;
 
 /**
+ * @module {{}} can-util/js/log/log log
+ * @parent can-util/js
+ * 
+ * Utilities for logging to the console.
+ */
+
+/**
+ * @function can-util/js/log/log.warn warn
+ * @parent can-util/js/log/log
+ * @description
+ * 
  * Adds a warning message to the console.
+ *
  * ```
  * canLog.warn("something evil");
  * ```
- * @param {String} out the message
+ *
+ * @signature `canLog.warn(msg)`
+ * @param {String} msg the message to be logged.
  */
-exports.warn = function (out) {
+exports.warn = function(out) {
 	var ll = this.logLevel;
 	if (ll < 2) {
 		Array.prototype.unshift.call(arguments, 'WARN:');
@@ -17,26 +31,57 @@ exports.warn = function (out) {
 		} else if (typeof console !== "undefined" && console.log) {
 			this._logger("log", Array.prototype.slice.call(arguments));
 		} else if (window && window.opera && window.opera.postError) {
-			window.opera.postError("steal.js WARNING: " + out);
+			window.opera.postError("CanJS WARNING: " + out);
 		}
 	}
 };
 
 /**
+ * @function can-util/js/log/log.log log
+ * @parent can-util/js/log/log
+ * @description
  * Adds a message to the console.
+ *
  * ```
  * canLog.log("hi");
  * ```
- * @param {String} out the message
+ *
+ * @signature `canLog.log(msg)`
+ * @param {String} msg the message
  */
-exports.log = function (out) {
+exports.log = function(out) {
 	var ll = this.logLevel;
 	if (ll < 1) {
 		if (typeof console !== "undefined" && console.log) {
-			Array.prototype.unshift.call(arguments, 'Info:');
+			Array.prototype.unshift.call(arguments, 'INFO:');
 			this._logger("log", Array.prototype.slice.call(arguments));
 		} else if (window && window.opera && window.opera.postError) {
-			window.opera.postError("steal.js INFO: " + out);
+			window.opera.postError("CanJS INFO: " + out);
+		}
+	}
+};
+
+/**
+ * @function can-util/js/log/log.error error
+ * @parent can-util/js/log/log
+ * @description
+ * Adds an error message to the console.
+ *
+ * ```
+ * canLog.error(new Error("Oh no!"));
+ * ```
+ *
+ * @signature `canLog.error(err)`
+ * @param {String|Error} err The error to be logged.
+ */
+exports.error = function(out) {
+	var ll = this.logLevel;
+	if (ll < 1) {
+		if (typeof console !== "undefined" && console.error) {
+			Array.prototype.unshift.call(arguments, 'ERROR:');
+			this._logger("error", Array.prototype.slice.call(arguments));
+		} else if (window && window.opera && window.opera.postError) {
+			window.opera.postError("ERROR: " + out);
 		}
 	}
 };

--- a/js/log/log.js
+++ b/js/log/log.js
@@ -1,0 +1,50 @@
+exports.warnTimeout = 5000;
+exports.logLevel = 0;
+
+/**
+ * Adds a warning message to the console.
+ * ```
+ * canLog.warn("something evil");
+ * ```
+ * @param {String} out the message
+ */
+exports.warn = function (out) {
+	var ll = this.logLevel;
+	if (ll < 2) {
+		Array.prototype.unshift.call(arguments, 'WARN:');
+		if (typeof console !== "undefined" && console.warn) {
+			this._logger("warn", Array.prototype.slice.call(arguments));
+		} else if (typeof console !== "undefined" && console.log) {
+			this._logger("log", Array.prototype.slice.call(arguments));
+		} else if (window && window.opera && window.opera.postError) {
+			window.opera.postError("steal.js WARNING: " + out);
+		}
+	}
+};
+
+/**
+ * Adds a message to the console.
+ * ```
+ * canLog.log("hi");
+ * ```
+ * @param {String} out the message
+ */
+exports.log = function (out) {
+	var ll = this.logLevel;
+	if (ll < 1) {
+		if (typeof console !== "undefined" && console.log) {
+			Array.prototype.unshift.call(arguments, 'Info:');
+			this._logger("log", Array.prototype.slice.call(arguments));
+		} else if (window && window.opera && window.opera.postError) {
+			window.opera.postError("steal.js INFO: " + out);
+		}
+	}
+};
+
+exports._logger = function (type, arr) {
+	try {
+		console[type].apply(console, arr);
+	} catch(e) {
+		console[type](arr);
+	}
+};

--- a/js/log/test.html
+++ b/js/log/test.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<script src="../../node_modules/steal/steal.js" main="can-util/js/log/log-test"></script>

--- a/js/tests.js
+++ b/js/tests.js
@@ -6,6 +6,7 @@ require('./cid-set/cid-set-test');
 require('./deep-assign/deep-assign-test');
 require('./defaults/defaults-test');
 require('./dev/dev-test');
+require('./log/log-test');
 require('./diff/diff-test');
 require('./diff-array/diff-array-test');
 require('./diff-object/diff-object-test');


### PR DESCRIPTION
This adds a new module, can-util/log/log which can be used for logging.
This is like can-util/dev/dev, but is useful in production as well.

This also changes can-util/dev/dev to use can-util/log/log, but to
become noops in production.