### PR TITLE
Implement can-util/dom/location/location

### DIFF
--- a/dom/location/location-test.html
+++ b/dom/location/location-test.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+	<title>matches tests</title>
+</head>
+<body>
+<div id="qunit-fixture"></div>
+<script src="../../node_modules/steal/steal.js"
+		data-main="can-util/dom/location/location-test"></script>
+</body>
+</html>

--- a/dom/location/location-test.js
+++ b/dom/location/location-test.js
@@ -1,0 +1,13 @@
+var LOCATION = require("./location");
+QUnit = require("steal-qunit");
+
+QUnit.module("can-util/dom/location/location");
+
+QUnit.test("Can set a location", function(){
+	var myLoc = {};
+	var oldLoc = LOCATION();
+	LOCATION(myLoc);
+
+	QUnit.equal(LOCATION(), myLoc, "It was set");
+	LOCATION(oldLoc);
+});

--- a/dom/location/location.js
+++ b/dom/location/location.js
@@ -1,0 +1,29 @@
+var global = require("../../js/global/global");
+
+/**
+ * @module {function} can-util/dom/location/location location
+ * @parent can-util/dom
+ * @signature `location(location)`
+ *
+ * @param {Object} location An optional location-like object
+ * to set as the context's location
+ *
+ * Optionally sets, and returns, the location object for the context.
+ *
+ * ```js
+ * var locationShim = { path: '/' };
+ * var LOCATION = require("can-util/dom/location/location");
+ * LOCATION(locationShim);
+ *
+ * ...
+ * LOCATION().path; // -> '/'
+ * ```
+ */
+var setLocation;
+module.exports = function(setLoc){
+	if(setLoc) {
+		setLocation = setLoc;
+	}
+	//return setDocument || global().document;
+	return setLocation || global().location;
+};

--- a/dom/tests.js
+++ b/dom/tests.js
@@ -6,3 +6,4 @@ require("./events/inserted/inserted-test");
 require("./events/removed/removed-test");
 require("./mutate/mutate-test");
 require("./matches/matches-test");
+require("./location/location-test");


### PR DESCRIPTION
This adds a location getter/setter function similar to what we have for
the document and global objects. This is needed for SSR, in which case
we want to create a new `location` object for each request.