### PR TITLE
Issues/184/checked undefined

### DIFF
--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -714,3 +714,16 @@ test('multi-select does not dispatch a values change event if its selected optio
 		QUnit.start();
 	}, 50);
 });
+
+test('setting checked to undefined should result in false for checkboxes (#184)', function(){
+	var input = document.createElement('input');
+	input.type = 'checkbox';
+
+	domAttr.set(input, 'checked', undefined);
+	QUnit.equal(input.checked, false, 'Should set checked to false');
+	
+	domAttr.set(input, 'checked', true);
+	QUnit.equal(input.checked, true, 'Should become true');
+	domAttr.set(input, 'checked', undefined);
+	QUnit.equal(input.checked, false, 'Should become false again');
+});

--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -128,7 +128,11 @@ var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true},
 					return this.checked;
 				},
 				set: function(val){
-					var notFalse = !!val || val === undefined || val === "";
+					// - `set( truthy )` => TRUE
+					// - `set( "" )`     => TRUE
+					// - `set()`         => TRUE
+					// - `set(undefined)` => false.
+					var notFalse = !!val || val === "" || arguments.length === 0;
 					this.checked = notFalse;
 					if(notFalse && this.type === "radio") {
 						this.defaultChecked = true;
@@ -433,7 +437,14 @@ var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true},
 			// call its setter, and if so use the setter.
 			// Otherwise fallback to setAttribute.
 			if(typeof setter === "function" && test.call(el)) {
-				newValue = setter.call(el, val);
+				// To distinguish calls with explicit undefined, e.g.:
+				// - `attr.set(el, "checked")`
+				// - `attr.set(el, "checked", undefined)`
+				if (arguments.length === 2){
+					newValue = setter.call(el);
+				} else {
+					newValue = setter.call(el, val);
+				}
 			} else {
 				attr.setAttribute(el, attrName, val);
 			}


### PR DESCRIPTION
This allows to call `attr.set` with explicit `undefined` value:

```js
attr.set( el, "checked", truthy );            // => true
attr.set( el, "checked", "" );                // => true
attr.set( el, "checked" );                    // => true
attr.set( el, "checked", undefined );         // => FALSE
```

`can-stache-bindings` tests are passing with this change.