### PR TITLE
Issues/187/ajax cors

### DIFF
--- a/dom/ajax/ajax-test.js
+++ b/dom/ajax/ajax-test.js
@@ -108,6 +108,48 @@ if(typeof XDomainRequest === 'undefined') {
 			start();
 		});
 	});
+	
+	// Test GET CORS:
+	QUnit.asyncTest("GET CORS should set content-type header (#187)", function () {
+
+		var hasCorrectHeader, restore;
+		restore = makeFixture(function () {
+			this.open = function (type, url) {
+			};
+
+			this.send = function () {
+				this.readyState = 4;
+				this.status = 200;
+				this.onreadystatechange();
+			};
+
+			this.setRequestHeader = function (header, value) {
+				if (header === "Content-Type" && value === "application/x-www-form-urlencoded"){
+					hasCorrectHeader = true;
+				}
+				var o = {};
+				o[header] = value;
+				this.responseText = JSON.stringify(o);
+			};
+		});
+		
+		ajax({
+			url: "http://query.yahooapis.com/v1/public/yql",
+			data: {
+				fmt: "JSON",
+				q: 'select * from geo.places where text="sunnyvale, ca"',
+				format: "json"
+			}
+		}).then(function(response){
+			QUnit.ok(hasCorrectHeader, "Content-Type for GET CORS should be set to `application/x-www-form-urlencoded`");
+			restore();
+			start();
+		}, function(err){
+			QUnit.ok(false, "Should be resolved");
+			restore();
+			start();
+		});
+	});
 }
 
 if(System.env !== 'canjs-test' && __dirname !== '/') {

--- a/dom/ajax/ajax-test.js
+++ b/dom/ajax/ajax-test.js
@@ -109,39 +109,52 @@ if(typeof XDomainRequest === 'undefined') {
 		});
 	});
 	
-	// Test GET CORS:
-	QUnit.asyncTest("GET CORS should set content-type header (#187)", function () {
+	// Test simple GET CORS:
+	QUnit.asyncTest("GET CORS should be a simple request - without a preflight (#187)", function () {
 
-		var hasCorrectHeader, restore;
+		// CORS simple requests: https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Simple_requests
+		var isSimpleRequest = true, restore;
+		var simpleMethods = ['GET', 'POST', 'HEAD'];
+		var simpleHeaders = [
+			'Accept','Accept-Language','Content-Language','Content-Type',
+			'DPR', 'Downlink', 'Save-Data', 'Viewport-Width', 'Width'
+		];
+		var simpleContentType = 'application/x-www-form-urlencoded';
+		
 		restore = makeFixture(function () {
 			this.open = function (type, url) {
+				if (simpleMethods.indexOf(type) === -1){
+					isSimpleRequest = false;
+				}
 			};
 
+			var response = {};
 			this.send = function () {
+				this.responseText = JSON.stringify(response);
 				this.readyState = 4;
 				this.status = 200;
 				this.onreadystatechange();
 			};
-
+		
 			this.setRequestHeader = function (header, value) {
-				if (header === "Content-Type" && value === "application/x-www-form-urlencoded"){
-					hasCorrectHeader = true;
+				if (header === "Content-Type" && value !== simpleContentType){
+					isSimpleRequest = false;
 				}
-				var o = {};
-				o[header] = value;
-				this.responseText = JSON.stringify(o);
+				if (simpleHeaders.indexOf(header) === -1){
+					isSimpleRequest = false;
+				}
+				response[header] = value;
 			};
 		});
 		
 		ajax({
 			url: "http://query.yahooapis.com/v1/public/yql",
 			data: {
-				fmt: "JSON",
 				q: 'select * from geo.places where text="sunnyvale, ca"',
 				format: "json"
 			}
 		}).then(function(response){
-			QUnit.ok(hasCorrectHeader, "Content-Type for GET CORS should be set to `application/x-www-form-urlencoded`");
+			QUnit.ok(isSimpleRequest, "CORS GET is simple");
 			restore();
 			start();
 		}, function(err){

--- a/dom/ajax/ajax.js
+++ b/dom/ajax/ajax.js
@@ -159,17 +159,24 @@ module.exports = namespace.ajax = function (o) {
 	}
 	xhr.open(type, url);
 
-	var isJson = o.dataType.indexOf("json") >= 0;
+	// For CORS to send a "simple" request (to avoid a preflight check), the following methods are allowed: GET/POST/HEAD,
+	// see https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Simple_requests
+	var isSimpleCors = o.crossDomain && ['GET', 'POST', 'HEAD'].indexOf(type) !== -1;
+	
 	if (isPost) {
-		data = (isJson && !o.crossDomain) ?
+		var isJson = o.dataType.indexOf("json") >= 0;
+		data = (isJson && !isSimpleCors) ?
 			(typeof o.data === "object" ? JSON.stringify(o.data) : o.data):
 			$._formData(o.data);
-		xhr.setRequestHeader("Content-Type", (isJson && !o.crossDomain) ? "application/json" : "application/x-www-form-urlencoded");
-	} else if (type === "GET" && o.crossDomain){
-		xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+
+		// CORS simple: `Content-Type` has to be `application/x-www-form-urlencoded`:
+		xhr.setRequestHeader("Content-Type", (isJson && !isSimpleCors) ? "application/json" : "application/x-www-form-urlencoded");
 	}
-	// X-Requested-With header
-	xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest" );
+	
+	// CORS simple: no custom headers, so we don't add `X-Requested-With` header:
+	if (!isSimpleCors){
+		xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest" );
+	}
 
 	xhr.send(data);
 	return promise;

--- a/dom/ajax/ajax.js
+++ b/dom/ajax/ajax.js
@@ -159,12 +159,14 @@ module.exports = namespace.ajax = function (o) {
 	}
 	xhr.open(type, url);
 
+	var isJson = o.dataType.indexOf("json") >= 0;
 	if (isPost) {
-		var isJson = o.dataType.indexOf("json") >= 0;
 		data = (isJson && !o.crossDomain) ?
 			(typeof o.data === "object" ? JSON.stringify(o.data) : o.data):
 			$._formData(o.data);
 		xhr.setRequestHeader("Content-Type", (isJson && !o.crossDomain) ? "application/json" : "application/x-www-form-urlencoded");
+	} else if (type === "GET" && o.crossDomain){
+		xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
 	}
 	// X-Requested-With header
 	xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest" );

--- a/dom/ajax/test.html
+++ b/dom/ajax/test.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+	<title>can-util/dom/ajax/ajax test</title>
+</head>
+<body>
+<div id="qunit-fixture"></div>
+<script src="../../node_modules/steal/steal.js"
+		data-main="can-util/dom/ajax/ajax-test"></script>
+</body>
+</html>


### PR DESCRIPTION
GET CORS should avoid custom headers. This is to avoid OPTIONS preflight checks.

Links:
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Simple_requests
- https://fetch.spec.whatwg.org/#http-fetch