### PR TITLE
Ajax refactor

### DIFF
--- a/doc/can-util.md
+++ b/doc/can-util.md
@@ -3,6 +3,5 @@
 @package ../package.json
 @group can-util/dom can-util/dom
 @group can-util/js can-util/js
-@group can-util/typedefs types
 
 Common JavaScript utilities for the rest of CanJS.

--- a/doc/can-util.md
+++ b/doc/can-util.md
@@ -3,5 +3,6 @@
 @package ../package.json
 @group can-util/dom can-util/dom
 @group can-util/js can-util/js
+@group can-util/typedefs types
 
 Common JavaScript utilities for the rest of CanJS.

--- a/dom/ajax/ajax.js
+++ b/dom/ajax/ajax.js
@@ -28,19 +28,14 @@ var param = require("../../js/param/param");
  *    });
  *    ```
  * 
- *    @param {can-util/typedefs/ajaxOptions} ajaxOptions Configuration options for the AJAX request.
- *      - __url__ {String} The requested url.
- *      - __type__ {String} The method of the request. Ex: `GET`, `PUT`, `POST`, etc. Capitalization is ignored. Default is `GET`.
- *      - __data__ {Object} The data of the request. If data needs to be urlencoded (e.g. for GET requests or for CORS) it is serialized with [can-util/js/param].
- *      - __dataType__ {String} Type of data. Default is `json`.
- *      - __crossDomain__ {Boolean} If you wish to force a crossDomain request (such as JSONP) on the same domain, set the value of crossDomain to true. This allows, for example, server-side redirection to another domain. Default: `false` for same-domain requests, `true` for cross-domain requests.
- *      - __timeout__ {Number} Set a timeout (in milliseconds) for the request. A value of 0 means there will be no timeout.
- *      - __timeoutFn__ {Function} Timeout callback to be called after `xhr.abort()`.
- *      - __success__ {Function} A function to be called if the request succeeds. The function gets passed one argument based on content type: `xhr.responseText`, `xhr.responseXML` or parsed JSON.
- *      - __error__ {Function} A function to be called if the request fails. The function receives three arguments: `xhr`, `xhr.status` and `xhr.statusText`. 
- *      - __complete__ {Function} A function to be called when the request finishes (after success and error callbacks are executed). The function gets passed two arguments: `xhr`, `xhr.statusText`.
- *      - __userAgent__ {String} Default: `XMLHttpRequest`.
- *      - __lang__ {String} Default `en`.
+ *    @param {Object} ajaxOptions Configuration options for the AJAX request.
+ *      - __url__ `{String}` The requested url.
+ *      - __type__ `{String}` The method of the request. Ex: `GET`, `PUT`, `POST`, etc. Capitalization is ignored. _Default is `GET`_.
+ *      - __data__ `{Object}` The data of the request. If data needs to be urlencoded (e.g. for GET requests or for CORS) it is serialized with [can-util/js/param].
+ *      - __dataType__ `{String}` Type of data. _Default is `json`_.
+ *      - __crossDomain__ `{Boolean}` If you wish to force a crossDomain request (such as JSONP) on the same domain, set the value of crossDomain to true. This allows, for example, server-side redirection to another domain. Default: `false` for same-domain requests, `true` for cross-domain requests.
+ *      - __userAgent__ `{String}` _Default: `XMLHttpRequest`_.
+ *      - __lang__ `{String}` _Default `en`_.
  *
  *    @return {Promise} A Promise that resolves to the data. The Promise instance is abortable and exposes an `abort` method. Invoking abort on the Promise instance indirectly rejects it.
  * 

--- a/dom/ajax/ajax.js
+++ b/dom/ajax/ajax.js
@@ -5,27 +5,45 @@ var parseURI = require('../../js/parse-uri/parse-uri');
 var param = require("../../js/param/param");
 
 /**
-@module {function} can-util/dom/ajax/ajax ajax
-@parent can-util/dom
-@signature `ajax(settings)`
-@param {Object} settings Configuration options for the AJAX request.
-The list of configuration options is the same as for [jQuery.ajax](http://api.jquery.com/jQuery.ajax/#jQuery-ajax-settings).
-@return {Promise} A Promise that resolves to the data. The Promise instance is abortable and exposes an `abort` method.
- Invoking abort on the Promise instance indirectly rejects it.
-
-@body
-`ajax( settings )` is used to make an asynchronous HTTP (AJAX) request
-similar to [http://api.jquery.com/jQuery.ajax/jQuery.ajax]. The example below
-makes use of [can-util/dom/frag/frag].
-
-        ajax({
-                url: 'http://canjs.com/docs/can.ajax.html',
-                success: function(document) {
-                        var frag = can.frag(document);
-                        return frag.querySelector(".heading h1").innerText; //-> ajax
-                }
-        });
-
+ * @module {function} can-util/dom/ajax/ajax ajax
+ * @parent can-util/dom
+ * 
+ * Make an asynchronous HTTP (AJAX) request.
+ * 
+ * @signature `ajax( ajaxOptions )`
+ * 
+ *    Is used to make an asynchronous HTTP (AJAX) request similar to [http://api.jquery.com/jQuery.ajax/jQuery.ajax].
+ *   
+ *    ```
+ *    var ajax = require("can-util/dom/ajax/ajax");
+ *    
+ *    ajax({
+ *      url: "http://query.yahooapis.com/v1/public/yql",
+ *      data: {
+ *        format: "json",
+ *        q: 'select * from geo.places where text="sunnyvale, ca"'
+ *      }
+ *    }).then(function(response){
+ *      console.log( response.query.count ); // => 2
+ *    });
+ *    ```
+ * 
+ *    @param {can-util/typedefs/ajaxOptions} ajaxOptions Configuration options for the AJAX request.
+ *      - __url__ {String} The requested url.
+ *      - __type__ {String} The method of the request. Ex: `GET`, `PUT`, `POST`, etc. Capitalization is ignored. Default is `GET`.
+ *      - __data__ {Object} The data of the request. If data needs to be urlencoded (e.g. for GET requests or for CORS) it is serialized with [can-util/js/param].
+ *      - __dataType__ {String} Type of data. Default is `json`.
+ *      - __crossDomain__ {Boolean} If you wish to force a crossDomain request (such as JSONP) on the same domain, set the value of crossDomain to true. This allows, for example, server-side redirection to another domain. Default: `false` for same-domain requests, `true` for cross-domain requests.
+ *      - __timeout__ {Number} Set a timeout (in milliseconds) for the request. A value of 0 means there will be no timeout.
+ *      - __timeoutFn__ {Function} Timeout callback to be called after `xhr.abort()`.
+ *      - __success__ {Function} A function to be called if the request succeeds. The function gets passed one argument based on content type: `xhr.responseText`, `xhr.responseXML` or parsed JSON.
+ *      - __error__ {Function} A function to be called if the request fails. The function receives three arguments: `xhr`, `xhr.status` and `xhr.statusText`. 
+ *      - __complete__ {Function} A function to be called when the request finishes (after success and error callbacks are executed). The function gets passed two arguments: `xhr`, `xhr.statusText`.
+ *      - __userAgent__ {String} Default: `XMLHttpRequest`.
+ *      - __lang__ {String} Default `en`.
+ *
+ *    @return {Promise} A Promise that resolves to the data. The Promise instance is abortable and exposes an `abort` method. Invoking abort on the Promise instance indirectly rejects it.
+ * 
  */
 
 // from https://gist.github.com/mythz/1334560

--- a/dom/ajax/ajax.js
+++ b/dom/ajax/ajax.js
@@ -34,8 +34,6 @@ var param = require("../../js/param/param");
  *      - __data__ `{Object}` The data of the request. If data needs to be urlencoded (e.g. for GET requests or for CORS) it is serialized with [can-util/js/param].
  *      - __dataType__ `{String}` Type of data. _Default is `json`_.
  *      - __crossDomain__ `{Boolean}` If you wish to force a crossDomain request (such as JSONP) on the same domain, set the value of crossDomain to true. This allows, for example, server-side redirection to another domain. Default: `false` for same-domain requests, `true` for cross-domain requests.
- *      - __userAgent__ `{String}` _Default: `XMLHttpRequest`_.
- *      - __lang__ `{String}` _Default `en`_.
  *
  *    @return {Promise} A Promise that resolves to the data. The Promise instance is abortable and exposes an `abort` method. Invoking abort on the Promise instance indirectly rejects it.
  * 

--- a/js/param/param-test.js
+++ b/js/param/param-test.js
@@ -1,0 +1,11 @@
+var QUnit = require("../../test/qunit");
+var param = require("./param");
+
+QUnit.module("can-util/js/param");
+
+QUnit.test("param", function(){
+	QUnit.deepEqual( param( {foo: "bar", baz: "zed"} ), "foo=bar&baz=zed", "Regular object");
+	QUnit.deepEqual( param( {foo: {bar: "baz"}} ), encodeURI("foo[bar]=baz"), "Nested object");
+	QUnit.deepEqual( param( {foo: ["bar", "baz"]} ), encodeURI("foo[]=bar&foo[]=baz"), "Nested array");
+	QUnit.deepEqual( param( {foo: "bar & baz"} ), "foo=bar+%26+baz", "Spec chars values");
+});

--- a/js/param/param.md
+++ b/js/param/param.md
@@ -8,15 +8,15 @@ Serializes an object or array into a query string useful for making Ajax request
 escape values and keys.
 
 ```js
-var deparam = require("can-util/js/param/param");
+var param = require("can-util/js/param/param");
 
 param({foo: "bar"})          //-> "foo=bar"
 param({foo: ["bar", "baz"]}) //-> "foo[]=bar&foo[]=baz"
 param({foo: {bar: "baz"}})    //-> "foo[bar]=baz"
-param({foo: "bar & baz"})    //-> "foo=bar%20%26%20baz"
+param({foo: "bar & baz"})    //-> "foo=bar+%26+baz"
 ```
 
 This is exported as `param` on [can-namespace].
 
-@param {Object} object An object or array..
-@return {String} The params formatted into an form-encoded string.
+@param {Object} object An object or array.
+@return {String} The params formatted into a form-encoded string.

--- a/js/tests.js
+++ b/js/tests.js
@@ -37,4 +37,5 @@ require('./make-array/make-array-test');
 require('./make-map/make-map-test');
 require('./set-not-enumerable/set-not-enumerable-test');
 require('./string/string-test');
-require("./string-to-any/string-to-any-test");
+require('./string-to-any/string-to-any-test');
+require('./param/param-test');


### PR DESCRIPTION
Updated `dom/ajax/ajax` to use `can-util/js/params` as well as some var names.
Added a test for params.
Fixed some ajax and params docs.