### PR TITLE
Firefox throws an error when a custom event is dispatched on a disabled input element

### DIFF
--- a/dom/dispatch/dispatch-test.js
+++ b/dom/dispatch/dispatch-test.js
@@ -17,6 +17,19 @@ test("basic synthetic events", function () {
 
 });
 
+test("synthetic events on disabled element", function () {
+	expect(1);
+	var input = document.createElement("input");
+	input.disabled = true;
+
+	domEvents.addEventListener.call(input, "foo", function(){
+		ok(true, "called back");
+	});
+
+	document.getElementById("qunit-fixture").appendChild(input);
+	domDispatch.call(input, "foo", [], false);
+});
+
 test("more complex synthetic events", function () {
 	var div = document.createElement("div");
 	var arr = [];

--- a/dom/events/events.js
+++ b/dom/events/events.js
@@ -22,6 +22,8 @@ module.exports = {
 	},
 	dispatch: function(event, args, bubbles){
 		var doc = _document();
+		var ret;
+		var dispatchingOnDisabled = this.disabled;
 
 		var ev = doc.createEvent('HTMLEvents');
 		var isString = typeof event === "string";
@@ -33,6 +35,16 @@ module.exports = {
 			assign(ev, event);
 		}
 		ev.args = args;
-		return this.dispatchEvent(ev);
+		// In FireFox, dispatching an event on a disabled element throws an error.
+		// So ensure the mutatedNode is not disabled.
+		// https://bugzilla.mozilla.org/show_bug.cgi?id=329509
+		if(dispatchingOnDisabled) {
+			this.disabled = false;
+		}
+		ret = this.dispatchEvent(ev);
+		if(dispatchingOnDisabled) {
+			this.disabled = true;
+		}
+		return ret;
 	}
 };

--- a/dom/events/inserted/inserted-test.js
+++ b/dom/events/inserted/inserted-test.js
@@ -17,8 +17,7 @@ function runTest(name, MUT_OBS) {
 		}
 	});
 
-
-	asyncTest("basic insertion with mutation observer", function () {
+	asyncTest("basic insertion", function () {
 		var div = document.createElement("div");
 
 		domEvents.addEventListener.call(div,"inserted", function(){
@@ -28,7 +27,9 @@ function runTest(name, MUT_OBS) {
 
 		domMutate.appendChild.call(document.getElementById("qunit-fixture"), div);
 	});
-	asyncTest("basic disabled insertion with mutation observer", function () {
+	
+	asyncTest("basic disabled insertion", function () {
+		expect(1);
 		var input = document.createElement("input");
 		input.disabled = true;
 
@@ -37,7 +38,10 @@ function runTest(name, MUT_OBS) {
 			start();
 		});
 
-		domMutate.appendChild.call(document.getElementById("qunit-fixture"), input);
+		// With no mutation observer this test will not pass without a setTimeout
+		setTimeout(function(){
+			domMutate.appendChild.call(document.getElementById("qunit-fixture"), input);
+		}, 20);
 	});
 	asyncTest("parent then child inserted - appendChild", function () {
 		expect(1);
@@ -66,7 +70,6 @@ function runTest(name, MUT_OBS) {
 			ok(true, "called back");
 			start();
 		});
-
 		domMutate.appendChild.call(document.getElementById("qunit-fixture"), div);
 	});
 

--- a/dom/events/inserted/inserted-test.js
+++ b/dom/events/inserted/inserted-test.js
@@ -28,6 +28,17 @@ function runTest(name, MUT_OBS) {
 
 		domMutate.appendChild.call(document.getElementById("qunit-fixture"), div);
 	});
+	asyncTest("basic disabled insertion with mutation observer", function () {
+		var input = document.createElement("input");
+		input.disabled = true;
+
+		domEvents.addEventListener.call(input,"inserted", function(){
+			ok(true, "called back");
+			start();
+		});
+
+		domMutate.appendChild.call(document.getElementById("qunit-fixture"), input);
+	});
 	asyncTest("parent then child inserted - appendChild", function () {
 		expect(1);
 		var div = document.createElement("div");

--- a/dom/events/make-mutation-event/make-mutation-event.js
+++ b/dom/events/make-mutation-event/make-mutation-event.js
@@ -37,10 +37,6 @@ module.exports = function(specialEventName, mutationNodesProperty){
 		}
 		dispatched.add(mutatedNode);
 		if(specialEventName === "removed") {
-			// In FireFox, dispatching an event on a disabled element throws an error.
-			// So ensure the mutatedNode is not disabled.
-			// https://bugzilla.mozilla.org/show_bug.cgi?id=329509
-			mutatedNode.disabled = false;
 			var documentElement = getDocument().documentElement;
 			if(documentElement.contains(mutatedNode)) {
 				doDispatch = false;

--- a/dom/events/make-mutation-event/make-mutation-event.js
+++ b/dom/events/make-mutation-event/make-mutation-event.js
@@ -37,6 +37,10 @@ module.exports = function(specialEventName, mutationNodesProperty){
 		}
 		dispatched.add(mutatedNode);
 		if(specialEventName === "removed") {
+			// In FireFox, dispatching an event on a disabled element throws an error.
+			// So ensure the mutatedNode is not disabled.
+			// https://bugzilla.mozilla.org/show_bug.cgi?id=329509
+			mutatedNode.disabled = false;
 			var documentElement = getDocument().documentElement;
 			if(documentElement.contains(mutatedNode)) {
 				doDispatch = false;

--- a/dom/events/removed/removed-test.js
+++ b/dom/events/removed/removed-test.js
@@ -42,6 +42,19 @@ if(_MutationObserver) {
 		document.getElementById("qunit-fixture").removeChild(div);
 	});
 
+	asyncTest("with mutation observer - disabled removal - removeChild", function () {
+		var input = document.createElement("input");
+		input.disabled = true;
+
+		domEvents.addEventListener.call(input,"removed", function(){
+			ok(true, "called back");
+			start();
+		});
+
+		document.getElementById("qunit-fixture").appendChild(input);
+		document.getElementById("qunit-fixture").removeChild(input);
+	});
+
 	asyncTest("with mutation observer - basic removal - replaceChild", function () {
 		var div = document.createElement("div");
 		var div2 = document.createElement("div");
@@ -112,7 +125,7 @@ if(_MutationObserver) {
 	});
 }
 
-asyncTest("basic insertion without mutation observer - removeChild", function(){
+asyncTest("basic removal without mutation observer - removeChild", function(){
 	getMutationObserver(null);
 
 	var div = document.createElement("div");
@@ -125,6 +138,22 @@ asyncTest("basic insertion without mutation observer - removeChild", function(){
 
 	domMutate.appendChild.call(document.getElementById("qunit-fixture"), div);
 	domMutate.removeChild.call(document.getElementById("qunit-fixture"), div);
+});
+
+asyncTest("disabled removal without mutation observer - removeChild", function(){
+	getMutationObserver(null);
+
+	var input = document.createElement("input");
+	input.disabled = true;
+
+	domEvents.addEventListener.call(input,"removed", function(){
+		ok(true, "called back");
+		getMutationObserver(_MutationObserver);
+		start();
+	});
+
+	domMutate.appendChild.call(document.getElementById("qunit-fixture"), input);
+	domMutate.removeChild.call(document.getElementById("qunit-fixture"), input);
 });
 
 asyncTest("basic insertion without mutation observer - replaceChild", function(){

--- a/dom/events/removed/removed-test.js
+++ b/dom/events/removed/removed-test.js
@@ -43,7 +43,7 @@ if(_MutationObserver) {
 	});
 
 	asyncTest("with mutation observer - disabled removal - removeChild", function () {
-		var input = document.createElement("input");
+		var input = document.createElement("removed");
 		input.disabled = true;
 
 		domEvents.addEventListener.call(input,"removed", function(){


### PR DESCRIPTION
Firefox throws a `NS_ERROR_UNEXPECTED` when custom events are dispatched on a disabled element.

There is a bug for this behavior that is over a decade old and shows no sign of resolution: https://bugzilla.mozilla.org/show_bug.cgi?id=329509

Here's a simple JSBin to reproduce: http://jsbin.com/wojesak/1/edit?html,js,output