### PR TITLE
fix <select> to consider <optgroup> <option>s

### DIFF
--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -436,7 +436,7 @@ test("Multiselect values is updated on any children added/removed", function(){
 	}
 });
 
-test("Select options within optgroups should be set properly", function() {
+test("Select options within optgroups should be set via `value` properly", function() {
 	function tag (tag, value) {
 		var el = document.createElement(tag);
 		if (value) {
@@ -467,6 +467,41 @@ test("Select options within optgroups should be set properly", function() {
 	equal(domAttr.get(select, 'value'), 'list2-item2', 'updated value');
 	equal(option11.selected, false, 'initial option is not selected');
 	equal(option22.selected, true, 'second option is selected');
+});
+
+test("Select options within optgroups should be set via `values` properly", function() {
+	function tag (tag, value) {
+		var el = document.createElement(tag);
+		if (value) {
+			el.value = value;
+		}
+		return el;
+	}
+
+	var select = tag('select');
+	select.multiple = true;
+	var optgroup1 = tag('optgroup');
+	var option11 = tag('option', 'list1-item1');
+	option11.selected = true; // initial selection
+	var option12 = tag('option', 'list1-item2');
+	var optgroup2 = tag('optgroup');
+	var option21 = tag('option', 'list2-item1');
+	var option22 = tag('option', 'list2-item2');
+
+	select.appendChild(optgroup1);
+	select.appendChild(optgroup2);
+	optgroup1.appendChild(option11);
+	optgroup1.appendChild(option12);
+	optgroup2.appendChild(option21);
+	optgroup2.appendChild(option22);
+
+	deepEqual(domAttr.get(select, 'values'), ['list1-item1'], 'initial value');
+
+	domAttr.set(select, 'values', ['list1-item2', 'list2-item2']);
+	deepEqual(domAttr.get(select, 'values'), ['list1-item2', 'list2-item2'], 'updated value');
+	equal(option11.selected, false, 'initial option is not selected');
+	equal(option12.selected, true, 'second option is selected');
+	equal(option22.selected, true, 'third option is selected');
 });
 
 test("Setting a value that will be appended later", function(){

--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -436,6 +436,39 @@ test("Multiselect values is updated on any children added/removed", function(){
 	}
 });
 
+test("Select options within optgroups should be set properly", function() {
+	function tag (tag, value) {
+		var el = document.createElement(tag);
+		if (value) {
+			el.value = value;
+		}
+		return el;
+	}
+
+	var select = tag('select');
+	var optgroup1 = tag('optgroup');
+	var option11 = tag('option', 'list1-item1');
+	option11.selected = true; // initial selection
+	var option12 = tag('option', 'list1-item2');
+	var optgroup2 = tag('optgroup');
+	var option21 = tag('option', 'list2-item1');
+	var option22 = tag('option', 'list2-item2');
+
+	select.appendChild(optgroup1);
+	select.appendChild(optgroup2);
+	optgroup1.appendChild(option11);
+	optgroup1.appendChild(option12);
+	optgroup2.appendChild(option21);
+	optgroup2.appendChild(option22);
+
+	equal(domAttr.get(select, 'value'), 'list1-item1', 'initial value');
+
+	domAttr.set(select, 'value', 'list2-item2');
+	equal(domAttr.get(select, 'value'), 'list2-item2', 'updated value');
+	equal(option11.selected, false, 'initial option is not selected');
+	equal(option22.selected, true, 'second option is selected');
+});
+
 test("Setting a value that will be appended later", function(){
 	var select = document.createElement("select");
 	var option1 = document.createElement("option");
@@ -721,7 +754,7 @@ test('setting checked to undefined should result in false for checkboxes (#184)'
 
 	domAttr.set(input, 'checked', undefined);
 	QUnit.equal(input.checked, false, 'Should set checked to false');
-	
+
 	domAttr.set(input, 'checked', true);
 	QUnit.equal(input.checked, true, 'Should become true');
 	domAttr.set(input, 'checked', undefined);

--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -84,22 +84,28 @@ var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true},
 			}
 		}
 	},
-	setChildOptions = function(el, value){
-		if(value != null) {
-			var child = el.firstChild,
-				hasSelected = false;
-			while(child) {
-				if(child.nodeName === "OPTION") {
-					if(value === child.value) {
-						hasSelected = child.selected = true;
-						break;
-					}
+	_findOptionToSelect = function (parent, value) {
+		var child = parent.firstChild;
+		while (child) {
+			if (child.nodeName === 'OPTION' && value === child.value) {
+				return child;
+			}
+			if (child.nodeName === 'OPTGROUP') {
+				var groupChild = _findOptionToSelect(child, value);
+				if (groupChild) {
+					return groupChild;
 				}
-				child = child.nextSibling;
 			}
-			if(!hasSelected) {
-				el.selectedIndex = -1;
-			}
+			child = child.nextSibling;
+		}
+	},
+	setChildOptions = function(el, value){
+		var option;
+		if (value != null) {
+			option = _findOptionToSelect(el, value);
+		}
+		if (option) {
+			option.selected = true;
 		} else {
 			el.selectedIndex = -1;
 		}
@@ -350,7 +356,7 @@ var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true},
 				},
 				set: function(values){
 					values = values || [];
-					
+
 					// set new DOM state
 					var child = this.firstChild;
 					while(child) {

--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -110,6 +110,32 @@ var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true},
 			el.selectedIndex = -1;
 		}
 	},
+	forEachOption = function (parent, fn) {
+		var child = parent.firstChild;
+		while (child) {
+			if (child.nodeName === 'OPTION') {
+				fn(child);
+			}
+			if (child.nodeName === 'OPTGROUP') {
+				forEachOption(child, fn);
+			}
+			child = child.nextSibling;
+		}
+	},
+	collectSelectedOptions = function (parent) {
+		var selectedValues = [];
+		forEachOption(parent, function (option) {
+			if (option.selected) {
+				selectedValues.push(option.value);
+			}
+		});
+		return selectedValues;
+	},
+	markSelectedOptions = function (parent, values) {
+		forEachOption(parent, function (option) {
+			option.selected = values.indexOf(option.value) !== -1;
+		});
+	},
 	// Create a handler, only once, that will set the child options any time
 	// the select's value changes.
 	setChildOptionsOnChange = function(select, aEL){
@@ -343,28 +369,13 @@ var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true},
 			},
 			values: {
 				get: function(){
-					var values = [];
-					var child = this.firstChild;
-					while(child) {
-						if(child.nodeName === "OPTION" && child.selected) {
-							values.push(child.value);
-						}
-						child = child.nextSibling;
-					}
-
-					return values;
+					return collectSelectedOptions(this);
 				},
 				set: function(values){
 					values = values || [];
 
 					// set new DOM state
-					var child = this.firstChild;
-					while(child) {
-						if(child.nodeName === "OPTION") {
-							child.selected = values.indexOf(child.value) !== -1;
-						}
-						child = child.nextSibling;
-					}
+					markSelectedOptions(this, values);
 
 					// store new DOM state
 					setData.set.call(this, "stickyValues", attr.get(this,"values") );


### PR DESCRIPTION
We were not searching within optgroups for setting the selection via `attr`. Now we do. 

**Note:** This does not recurse through the entire select subtree. Only nested `<optgroup>` and `<option>` nodes are considered. No other nodes will be recursed.