### PR TITLE
Counting the number of event handlers for each element/event combo

### DIFF
--- a/dom/events/removed/removed-test.js
+++ b/dom/events/removed/removed-test.js
@@ -123,6 +123,22 @@ if(_MutationObserver) {
 		div.insertBefore(p, span);
 		domMutate.removeChild.call(fixture, div2);
 	});
+
+	asyncTest("with mutation observer - remaining event handlers fire after one is removed (#236)", function () {
+		var div = document.createElement("div");
+
+		domEvents.addEventListener.call(div,"removed", function (){
+			ok(true, "called back");
+			start();
+		});
+
+		function removeTwo () {}
+		domEvents.addEventListener.call(div, "removed", removeTwo);
+		domEvents.removeEventListener.call(div, "removed", removeTwo);
+
+		document.getElementById("qunit-fixture").appendChild(div);
+		document.getElementById("qunit-fixture").removeChild(div);
+	});
 }
 
 asyncTest("basic removal without mutation observer - removeChild", function(){


### PR DESCRIPTION
This way, if multiple event handlers are set up and one is removed, the
remaining handlers will still be dispatched.

Closes https://github.com/canjs/can-util/issues/236.