### PR TITLE
Use strict

### DIFF
--- a/dom/ajax/ajax-test.js
+++ b/dom/ajax/ajax-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var ajax = require('can-util/dom/ajax/ajax');
 var namespace = require("can-namespace");
 var makeMap = require('can-util/js/make-map/make-map');

--- a/dom/ajax/ajax.js
+++ b/dom/ajax/ajax.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Global = require("../../js/global/global");
 var assign = require("../../js/assign/assign");
 var namespace = require("can-namespace");

--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var domAttr = require('../attr/attr');
 var domEvents = require('../events/events');
 var domData = require("../data/data");

--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // # can/util/attr.js
 // Central location for attribute changing to occur, used to trigger an
 // `attributes` event on elements. This enables the user to do (jQuery example): `$(el).bind("attributes", function(ev) { ... })` where `ev` contains `attributeName` and `oldValue`.

--- a/dom/child-nodes/child-nodes.js
+++ b/dom/child-nodes/child-nodes.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * @module {function} can-util/dom/child-nodes/child-nodes child-nodes
  * @parent can-util/dom

--- a/dom/class-name/class-name.js
+++ b/dom/class-name/class-name.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // From http://jaketrent.com/post/addremove-classes-raw-javascript/
 
 var has = function(className) {

--- a/dom/contains/contains.js
+++ b/dom/contains/contains.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function(child){
 	return this.contains(child);
 };

--- a/dom/data/core.js
+++ b/dom/data/core.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var isEmptyObject = require("../../js/is-empty-object/is-empty-object");
 
 var data = {};

--- a/dom/data/data-test.js
+++ b/dom/data/data-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var domData = require("./data");
 var domDataCore = require("./core");
 var diff = require("../../js/diff-object/diff-object");

--- a/dom/data/data.js
+++ b/dom/data/data.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var domDataCore = require("./core");
 var mutationDocument = require("../mutation-observer/document/document");
 

--- a/dom/dispatch/dispatch-test.js
+++ b/dom/dispatch/dispatch-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var domDispatch = require('can-util/dom/dispatch/');
 var domEvents = require('can-util/dom/events/');
 

--- a/dom/dispatch/dispatch.js
+++ b/dom/dispatch/dispatch.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var domEvents = require("../events/events");
 
 /**

--- a/dom/document/document.js
+++ b/dom/document/document.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var global = require("../../js/global/global");
 
 /**

--- a/dom/dom.js
+++ b/dom/dom.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
 	ajax: require('./ajax/ajax'),
 	attr: require('./attr/attr'),

--- a/dom/events/attributes/attributes.js
+++ b/dom/events/attributes/attributes.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var events = require("../events");
 var isOfGlobalDocument = require("../../is-of-global-document/is-of-global-document");
 var domData = require("../../data/data");

--- a/dom/events/delegate/delegate-test.js
+++ b/dom/events/delegate/delegate-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 require('can-util/dom/events/inserted/');
 var domEvents = require('can-util/dom/events/');
 var domDispatch = require('can-util/dom/dispatch/');

--- a/dom/events/delegate/delegate.js
+++ b/dom/events/delegate/delegate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var domEvents = require("../events");
 var domData = require("../../data/data");
 var domMatches = require("../../matches/matches");

--- a/dom/events/events.js
+++ b/dom/events/events.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var _document = require("../document/document");
 var isBrowserWindow = require("../../js/is-browser-window/is-browser-window");
 var isPlainObject = require("../../js/is-plain-object/is-plain-object");
@@ -39,9 +41,10 @@ module.exports = {
 		ev.initEvent(isString ? event : event.type, bubbles === undefined ? true : bubbles, false);
 
 		if(!isString) {
-			// TODO: make this work in strict mode
 			for (var prop in event) {
-				ev[prop] = event[prop];
+				if (ev[prop] === undefined) {
+					ev[prop] = event[prop];
+				}
 			}
 		}
 		ev.args = args;

--- a/dom/events/events.js
+++ b/dom/events/events.js
@@ -1,4 +1,3 @@
-var assign = require("../../js/assign/assign");
 var _document = require("../document/document");
 var isBrowserWindow = require("../../js/is-browser-window/is-browser-window");
 var isPlainObject = require("../../js/is-plain-object/is-plain-object");
@@ -40,7 +39,10 @@ module.exports = {
 		ev.initEvent(isString ? event : event.type, bubbles === undefined ? true : bubbles, false);
 
 		if(!isString) {
-			assign(ev, event);
+			// TODO: make this work in strict mode
+			for (var prop in event) {
+				ev[prop] = event[prop];
+			}
 		}
 		ev.args = args;
 		if(dispatchingOnDisabled) {

--- a/dom/events/inserted/inserted-test.js
+++ b/dom/events/inserted/inserted-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 require('can-util/dom/events/inserted/');
 var domEvents = require('can-util/dom/events/');
 var MUTATION_OBSERVER = require('can-util/dom/mutation-observer/');

--- a/dom/events/inserted/inserted.js
+++ b/dom/events/inserted/inserted.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var makeMutationEvent = require("../make-mutation-event/make-mutation-event");
 
 /**

--- a/dom/events/make-mutation-event/make-mutation-event.js
+++ b/dom/events/make-mutation-event/make-mutation-event.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // This sets up an inserted event to work through mutation observers if
 // mutation observers are present.  If they aren't you have to use
 // the mutate methods.

--- a/dom/events/removed/removed-test.js
+++ b/dom/events/removed/removed-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 require('can-util/dom/events/removed/');
 var each = require('can-util/js/each/');
 var domEvents = require('can-util/dom/events/');

--- a/dom/events/removed/removed.js
+++ b/dom/events/removed/removed.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var makeMutationEvent = require("../make-mutation-event/make-mutation-event");
 
 /**

--- a/dom/frag/frag.js
+++ b/dom/frag/frag.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var getDocument = require('../document/document');
 var fragment = require('../fragment/fragment');
 var each = require('../../js/each/each');

--- a/dom/fragment/fragment.js
+++ b/dom/fragment/fragment.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var getDocument = require("../document/document"),
 	childNodes = require("../child-nodes/child-nodes");
 // fragment.js

--- a/dom/is-of-global-document/is-of-global-document.js
+++ b/dom/is-of-global-document/is-of-global-document.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var getDocument = require('../document/document');
 module.exports = function(el) {
 	return (el.ownerDocument || el) === getDocument();

--- a/dom/location/location-test.js
+++ b/dom/location/location-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var LOCATION = require("./location");
 QUnit = require("steal-qunit");
 

--- a/dom/location/location.js
+++ b/dom/location/location.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var global = require("../../js/global/global");
 
 /**

--- a/dom/matches/matches-test.js
+++ b/dom/matches/matches-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var matches = require("./matches");
 
 QUnit = require("steal-qunit");

--- a/dom/matches/matches.js
+++ b/dom/matches/matches.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var matchesMethod = function(element) {
 	return element.matches || element.webkitMatchesSelector || element.webkitMatchesSelector ||
 		element.mozMatchesSelector || element.msMatchesSelector || element.oMatchesSelector;

--- a/dom/mutate/mutate-test.js
+++ b/dom/mutate/mutate-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var mutate = require('./mutate');
 var MUTATION_OBSERVER = require("../mutation-observer/mutation-observer");
 var DOCUMENT = require("../document/document");

--- a/dom/mutate/mutate.js
+++ b/dom/mutate/mutate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // # can/util/inserted
 // Used to alert interested parties of when an element is inserted into the DOM.
 // Given a list of elements, check if the first is in the DOM, and if so triggers the `inserted` event on all elements and their descendants.

--- a/dom/mutation-observer/document/document.js
+++ b/dom/mutation-observer/document/document.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var getDocument = require("../../document/document");
 var domDataCore = require("../../data/core");
 var MUTATION_OBSERVER = require("../../mutation-observer/mutation-observer");

--- a/dom/mutation-observer/mutation-observer.js
+++ b/dom/mutation-observer/mutation-observer.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var global = require("../../js/global/global")();
 var setMutationObserver;
 module.exports = function(setMO){

--- a/dom/tests.js
+++ b/dom/tests.js
@@ -1,3 +1,5 @@
+'use strict';
+
 require("./ajax/ajax-test");
 require("./attr/attr-test");
 require("./data/data-test");

--- a/js/assign/assign-test.js
+++ b/js/assign/assign-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var assign = require('./assign');
 var QUnit = require('../../test/qunit');
 

--- a/js/assign/assign.js
+++ b/js/assign/assign.js
@@ -22,7 +22,7 @@
  *
  * @return {Object} Returns the `target` argument.
  */
-
+'use strict';
 module.exports = function (d, s) {
 	for (var prop in s) {
 		d[prop] = s[prop];

--- a/js/assign/assign.js
+++ b/js/assign/assign.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * @module {function} can-util/js/assign/assign assign
  * @parent can-util/js
@@ -22,7 +24,6 @@
  *
  * @return {Object} Returns the `target` argument.
  */
-'use strict';
 module.exports = function (d, s) {
 	for (var prop in s) {
 		d[prop] = s[prop];

--- a/js/base-url/base-url-test.js
+++ b/js/base-url/base-url-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var getBaseUrl = require('./base-url');
 var getGlobal = require("../global/global");

--- a/js/base-url/base-url.js
+++ b/js/base-url/base-url.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var getGlobal = require("../global/global");
 
 /**

--- a/js/cid-map/cid-map-test.js
+++ b/js/cid-map/cid-map-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var CIDMap = require('./cid-map');
 

--- a/js/cid-map/cid-map.js
+++ b/js/cid-map/cid-map.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var GLOBAL = require("../global/global");
 var each = require("../each/each");
 var getCID = require("../cid/get-cid");

--- a/js/cid-set/cid-set-test.js
+++ b/js/cid-set/cid-set-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var CIDSet = require('./cid-set');
 

--- a/js/cid-set/cid-set.js
+++ b/js/cid-set/cid-set.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var GLOBAL = require("../global/global");
 var each = require("../each/each");
 var getCID = require("../cid/get-cid");

--- a/js/cid/cid.js
+++ b/js/cid/cid.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var canDev = require("../dev/dev");
 
 /**

--- a/js/cid/get-cid.js
+++ b/js/cid/get-cid.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var CID = require("can-cid");
 var domDataCore = require("../../dom/data/core");
 

--- a/js/deep-assign/deep-assign-test.js
+++ b/js/deep-assign/deep-assign-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var deepAssign = require('./deep-assign');
 

--- a/js/deep-assign/deep-assign.js
+++ b/js/deep-assign/deep-assign.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var isArray = require('../is-array/is-array');
 var isFunction = require('../is-function/is-function');
 var isPlainObject = require('../is-plain-object/is-plain-object');
@@ -16,6 +18,7 @@ function deepAssign() {
 
 	// extend jQuery itself if only one argument is passed
 	if (length === i) {
+		/*jshint validthis:true*/
 		target = this;
 		--i;
 	}

--- a/js/defaults/defaults-test.js
+++ b/js/defaults/defaults-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var defaults = require('./defaults');
 var QUnit = require('../../test/qunit');
 

--- a/js/defaults/defaults.js
+++ b/js/defaults/defaults.js
@@ -1,3 +1,5 @@
+'use strict';
+
 
 /**
  * @module {function} can-util/js/defaults/defaults defaults

--- a/js/deparam/deparam.js
+++ b/js/deparam/deparam.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var canDev = require("../dev/dev");
 
 /**

--- a/js/dev/dev-test.js
+++ b/js/dev/dev-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 
 require('./dev');

--- a/js/dev/dev.js
+++ b/js/dev/dev.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var canLog = require("../log/log");
 
 /**

--- a/js/diff-array/diff-array-test.js
+++ b/js/diff-array/diff-array-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var diffArray = require('./diff-array');
 

--- a/js/diff-array/diff-array.js
+++ b/js/diff-array/diff-array.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var diff = require('../diff/diff');
 
 module.exports = exports = diff;

--- a/js/diff-object/diff-object-test.js
+++ b/js/diff-object/diff-object-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var diffObject = require('./diff-object');
 

--- a/js/diff-object/diff-object.js
+++ b/js/diff-object/diff-object.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var assign = require('../assign/assign');
 
 /**

--- a/js/diff/diff-test.js
+++ b/js/diff/diff-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var diff = require('./diff');
 

--- a/js/diff/diff.js
+++ b/js/diff/diff.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var slice = [].slice;
 // a b c
 // a b c d

--- a/js/each/each-test.js
+++ b/js/each/each-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var each  = require('./each');
 var types = require('can-types');

--- a/js/each/each.js
+++ b/js/each/each.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* jshint maxdepth:7*/
 var isArrayLike = require('../is-array-like/is-array-like');
 var has = Object.prototype.hasOwnProperty;

--- a/js/get/get-test.js
+++ b/js/get/get-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 
 var get  = require('./get');

--- a/js/get/get.js
+++ b/js/get/get.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var isContainer = require('../is-container/is-container');
 
 /**

--- a/js/global/global-test.js
+++ b/js/global/global-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var getGlobal = require('./global');
 var isBrowserWindow = require('../is-browser-window/is-browser-window');

--- a/js/global/global-test.js
+++ b/js/global/global-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var QUnit = require('../../test/qunit');
 var getGlobal = require('./global');
 var isBrowserWindow = require('../is-browser-window/is-browser-window');

--- a/js/global/global.js
+++ b/js/global/global.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * @module {function} can-util/js/global/global global
  * @parent can-util/js

--- a/js/import/import-test.js
+++ b/js/import/import-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var load = require('./import');
 var isNode = require('../is-node/is-node')();

--- a/js/import/import.js
+++ b/js/import/import.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var isFunction = require('../is-function/is-function');
 var global = require("../global/global")();
 

--- a/js/import/testmodule.js
+++ b/js/import/testmodule.js
@@ -1,1 +1,3 @@
+'use strict';
+
 module.exports = 'Hello world';

--- a/js/is-array-like/is-array-like-test.js
+++ b/js/is-array-like/is-array-like-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var isArrayLike = require('./is-array-like');
 

--- a/js/is-array-like/is-array-like.js
+++ b/js/is-array-like/is-array-like.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // The following is from jQuery
 function isArrayLike(obj){
 	var type = typeof obj;

--- a/js/is-array/is-array-test.js
+++ b/js/is-array/is-array-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 
 var isArray  = require('./is-array');

--- a/js/is-array/is-array.js
+++ b/js/is-array/is-array.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function(arr) {
 	return Array.isArray(arr);
 };

--- a/js/is-browser-window/is-browser-window-test.js
+++ b/js/is-browser-window/is-browser-window-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var isBrowserWindow = require('./is-browser-window');
 

--- a/js/is-browser-window/is-browser-window.js
+++ b/js/is-browser-window/is-browser-window.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * @module {function} can-util/js/is-browser-window/is-browser-window is-browser-window
  * @parent can-util/js

--- a/js/is-container/is-container-test.js
+++ b/js/is-container/is-container-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 
 var isContainer  = require('./is-container');

--- a/js/is-container/is-container.js
+++ b/js/is-container/is-container.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // Returns `true` if the object can have properties (no `null`s).
 module.exports = function (current) {
     return /^f|^o/.test(typeof current);

--- a/js/is-empty-object/is-empty-object-test.js
+++ b/js/is-empty-object/is-empty-object-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var isEmptyObject = require("./is-empty-object");
 var QUnit = require("../../test/qunit");
 

--- a/js/is-empty-object/is-empty-object.js
+++ b/js/is-empty-object/is-empty-object.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* jshint unused: false */
 
 /**

--- a/js/is-function/is-function-test.js
+++ b/js/is-function/is-function-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var isFunction = require('./is-function');
 

--- a/js/is-function/is-function.js
+++ b/js/is-function/is-function.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * @module {function} can-util/js/is-function/is-function is-function
  * @parent can-util/js

--- a/js/is-iterable/is-iterable.js
+++ b/js/is-iterable/is-iterable.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var types = require("can-types");
 
 module.exports = function(obj) {

--- a/js/is-node/is-node-test.js
+++ b/js/is-node/is-node-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var isNode = require('./is-node');
 

--- a/js/is-node/is-node.js
+++ b/js/is-node/is-node.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * @module {function} can-util/js/is-node/is-node is-node
  * @parent can-util/js

--- a/js/is-plain-object/is-plain-object-test.js
+++ b/js/is-plain-object/is-plain-object-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var isPlainObject = require('./is-plain-object');
 

--- a/js/is-plain-object/is-plain-object.js
+++ b/js/is-plain-object/is-plain-object.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var core_hasOwn = Object.prototype.hasOwnProperty;
 
 function isWindow(obj) {

--- a/js/is-promise-like/is-promise-like-test.js
+++ b/js/is-promise-like/is-promise-like-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var isPromise = require('./is-promise-like');
 

--- a/js/is-promise-like/is-promise-like.js
+++ b/js/is-promise-like/is-promise-like.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * @module {function} can-util/js/is-promise-like/is-promise-like is-promise-like
  * @parent can-util/js

--- a/js/is-promise/is-promise.js
+++ b/js/is-promise/is-promise.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var types = require('can-types');
 /**
  * @module {function} can-util/js/is-promise/is-promise is-promise

--- a/js/is-string/is-string-test.js
+++ b/js/is-string/is-string-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var isString = require('./is-string');
 

--- a/js/is-string/is-string.js
+++ b/js/is-string/is-string.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * @module {function} can-util/js/is-string/is-string is-string
  * @parent can-util/js

--- a/js/is-web-worker/is-web-worker-test.js
+++ b/js/is-web-worker/is-web-worker-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var isWebWorker = require('./is-web-worker');
 

--- a/js/is-web-worker/is-web-worker.js
+++ b/js/is-web-worker/is-web-worker.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * @module {function} can-util/js/is-web-worker/is-web-worker is-web-worker
  * @parent can-util/js

--- a/js/join-uris/join-uris-test.js
+++ b/js/join-uris/join-uris-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var joinURIs = require('./join-uris');
 

--- a/js/join-uris/join-uris.js
+++ b/js/join-uris/join-uris.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var parseURI = require('../parse-uri/parse-uri');
 
 module.exports = function(base, href) {

--- a/js/js.js
+++ b/js/js.js
@@ -1,3 +1,5 @@
+'use strict';
+
 
 
 module.exports = {

--- a/js/last/last-test.js
+++ b/js/last/last-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var last = require('./last');
 

--- a/js/last/last.js
+++ b/js/last/last.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function(arr){
 	return arr && arr[arr.length - 1];
 };

--- a/js/log/log-test.js
+++ b/js/log/log-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require("../../test/qunit");
 var canLog = require("./log");
 

--- a/js/log/log.js
+++ b/js/log/log.js
@@ -1,3 +1,5 @@
+'use strict';
+
 exports.warnTimeout = 5000;
 exports.logLevel = 0;
 

--- a/js/make-array/make-array-test.js
+++ b/js/make-array/make-array-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var makeArray = require('./make-array');
 

--- a/js/make-array/make-array.js
+++ b/js/make-array/make-array.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var each = require('../each/each');
 var isArrayLike = require('../is-array-like/is-array-like');
 

--- a/js/make-map/make-map-test.js
+++ b/js/make-map/make-map-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var makeMap = require('./make-map');
 

--- a/js/make-map/make-map.js
+++ b/js/make-map/make-map.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var each = require('../each/each');
 
 /**

--- a/js/make-promise/make-promise-test.js
+++ b/js/make-promise/make-promise-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var isPromise = require('../is-promise/is-promise');
 var makePromise = require('./make-promise');

--- a/js/make-promise/make-promise.js
+++ b/js/make-promise/make-promise.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * @module {function} can-util/js/make-promise/make-promise make-promise
  * @parent can-util/js

--- a/js/omit/omit-test.js
+++ b/js/omit/omit-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var omit = require('./omit');
 var QUnit = require('../../test/qunit');
 

--- a/js/omit/omit.js
+++ b/js/omit/omit.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * @module {function} can-util/js/omit/omit omit
  * @parent can-util/js

--- a/js/param/param.js
+++ b/js/param/param.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var canDev = require("../dev/dev");
 
 /**

--- a/js/parse-uri/parse-uri-test.js
+++ b/js/parse-uri/parse-uri-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var parseURI = require('./parse-uri');
 

--- a/js/parse-uri/parse-uri.js
+++ b/js/parse-uri/parse-uri.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function(url){
 		var m = String(url).replace(/^\s+|\s+$/g, '').match(/^([^:\/?#]+:)?(\/\/(?:[^:@]*(?::[^:@]*)?@)?(([^:\/?#]*)(?::(\d*))?))?([^?#]*)(\?[^#]*)?(#[\s\S]*)?/);
 			// authority = '//' + user + ':' + pass '@' + hostname + ':' port

--- a/js/set-immediate/set-immediate.js
+++ b/js/set-immediate/set-immediate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var global = require("../global/global")();
 
 /**

--- a/js/set-not-enumerable/set-not-enumerable-test.js
+++ b/js/set-not-enumerable/set-not-enumerable-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var setNotEnumerable = require('./set-not-enumerable');
 

--- a/js/set-not-enumerable/set-not-enumerable.js
+++ b/js/set-not-enumerable/set-not-enumerable.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function(obj, prop, value){
 	Object.defineProperty(obj, prop, {
 		configurable: true,

--- a/js/string-to-any/string-to-any-test.js
+++ b/js/string-to-any/string-to-any-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require("../../test/qunit");
 var stringToAny = require("./string-to-any");
 var each = require("../each/each");

--- a/js/string-to-any/string-to-any.js
+++ b/js/string-to-any/string-to-any.js
@@ -1,3 +1,5 @@
+'use strict';
+
 
 module.exports = function(str){
 	switch(str) {

--- a/js/string/string-test.js
+++ b/js/string/string-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var QUnit = require('../../test/qunit');
 var string = require('./string');
 

--- a/js/string/string.js
+++ b/js/string/string.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var get = require('../get/get');
 var isContainer = require('../is-container/is-container');
 var canDev = require("../dev/dev");

--- a/js/tests.js
+++ b/js/tests.js
@@ -1,3 +1,5 @@
+'use strict';
+
 require('./assign/assign-test');
 require('./base-url/base-url-test');
 require('./cid-map/cid-map-test');

--- a/js/types/types.js
+++ b/js/types/types.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var canDev = require("../dev/dev");
 
 /**


### PR DESCRIPTION
This makes all `can-util` functions `"use strict";`. This was tested against CanJS 3.5.1.