### PR TITLE
Check if an element is contained within the documentElement

### DIFF
--- a/dom/mutate/mutate-test.html
+++ b/dom/mutate/mutate-test.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html>
-<head> </head>
+<head>
+	<title>mutate tests</title>
+</head>
 <body>
 <div id="qunit-fixture"></div>
 <script src="../../node_modules/steal/steal.js"

--- a/dom/mutate/mutate-test.js
+++ b/dom/mutate/mutate-test.js
@@ -3,6 +3,7 @@
 var mutate = require('./mutate');
 var MUTATION_OBSERVER = require("../mutation-observer/mutation-observer");
 var DOCUMENT = require("../document/document");
+var makeDocument = require("can-vdom/make-document/make-document");
 
 QUnit = require('steal-qunit');
 
@@ -32,7 +33,46 @@ test("inserting empty frag", function () {
 		enableMO();
 		start();
 	},10);
+});
 
+test("removing the body causes removed events", function () {
+	var enableMO = disableMO();
+	var oldDoc = DOCUMENT();
+
+	var doc = makeDocument();
+	DOCUMENT(doc);
+
+	var div = doc.createElement("div");
+	mutate.appendChild.call(doc.body, div);
+
+	div.addEventListener("removed", function(){
+		ok(true, "called");
+	});
+
+	mutate.removeChild.call(doc.documentElement, doc.body);
+
+	stop();
+	setTimeout(function(){
+		enableMO();
+		DOCUMENT(oldDoc);
+		start();
+	},10);
+
+	/*
+	var frag = document.createDocumentFragment();
+	mutate.appendChild.call( document.getElementById("qunit-fixture"), frag );
+
+	var div = document.createElement("div");
+	div.addEventListener("inserted", function(){
+		ok(true, "called");
+	});
+	mutate.appendChild.call( document.getElementById("qunit-fixture"), div );
+	stop();
+	setTimeout(function(){
+		enableMO();
+		start();
+	},10);
+	*/
 });
 
 if(window.eventsBubble) {

--- a/dom/mutate/mutate.js
+++ b/dom/mutate/mutate.js
@@ -70,7 +70,7 @@ var fireMutations = function(){
 
 	var firstElement = mutations[0][1][0];
 	var doc = DOCUMENT() || firstElement.ownerDocument || firstElement;
-	var root = doc.contains ? doc : doc.body;
+	var root = doc.contains ? doc : doc.documentElement;
 	var dispatched = {inserted: {}, removed: {}};
 	mutations.forEach(function(mutation){
 		fireOn(mutation[1], root, checks[mutation[0]], mutation[0], dispatched[mutation[0]]);
@@ -81,7 +81,7 @@ var mutated = function(elements, type) {
 		// make sure this element is in the page (mutated called before something is removed)
 		var firstElement = elements[0];
 		var doc = DOCUMENT() || firstElement.ownerDocument || firstElement;
-		var root = doc.contains ? doc : doc.body;
+		var root = doc.contains ? doc : doc.documentElement;
 		if( checks.inserted(root, firstElement) ) {
 
 			// if it is, schedule a mutation fire

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "async": "^2.2.0",
     "bit-docs": "0.0.7",
+    "can-vdom": "^3.0.3",
     "done-serve": "^1.0.0",
     "donejs-cli": "^1.0.0",
     "generator-donejs": "^1.0.0",


### PR DESCRIPTION
When document.contains doesn't exist, use the documentElement rather than the body. This enables removing the body and having the "removed" event fire on every element. Closes #251