### PR TITLE
fix(enter-leave): patch require patch for cjs

### DIFF
--- a/dom/events/delegate/enter-leave.js
+++ b/dom/events/delegate/enter-leave.js
@@ -10,7 +10,7 @@
  */
 
 var domEvents = require("../events"),
-	singleRef = require("../../../js/single-reference/"),
+	singleRef = require("../../../js/single-reference/single-reference"),
 	cid = require("../../../js/cid/get-cid");
 
 // Some mouse/pointer events do not bubble so we derive these events from other


### PR DESCRIPTION
the current build does not work with commonjs builds. Adding the full path here to get things
working again.