### PR TITLE
Make focused attribute wait for inserted if element is detached

### DIFF
--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -614,20 +614,19 @@ test("attr.special.focused calls after previous events", function(){
 	equal(domAttr.get(input, "focused"), false, "not focused yet");
 });
 
-test("attr.special.focused binds on inserted if element is detached", function(){
+test("attr.special.focused binds on inserted if element is detached", 2, function(){
 	var input = document.createElement("input");
 	input.type = "text";
 	var ta = document.getElementById("qunit-fixture");
 
 	stop();
-
 	domAttr.set(input, "focused", true);
 	equal(domAttr.get(input, "focused"), false, "not focused yet");
 	domEvents.addEventListener.call(input, "inserted", function() {
 		equal(domAttr.get(input, "focused"), true, "it is now focused");
 		start();		
 	});
-	ta.appendChild(input);
+	mutate.appendChild.call(ta, input);
 
 });
 

--- a/dom/attr/attr-test.js
+++ b/dom/attr/attr-test.js
@@ -614,6 +614,23 @@ test("attr.special.focused calls after previous events", function(){
 	equal(domAttr.get(input, "focused"), false, "not focused yet");
 });
 
+test("attr.special.focused binds on inserted if element is detached", function(){
+	var input = document.createElement("input");
+	input.type = "text";
+	var ta = document.getElementById("qunit-fixture");
+
+	stop();
+
+	domAttr.set(input, "focused", true);
+	equal(domAttr.get(input, "focused"), false, "not focused yet");
+	domEvents.addEventListener.call(input, "inserted", function() {
+		equal(domAttr.get(input, "focused"), true, "it is now focused");
+		start();		
+	});
+	ta.appendChild(input);
+
+});
+
 test("handles removing multiple event handlers", function () {
 	var handler1 = function() {};
 	var handler2 = function() {};

--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -205,16 +205,30 @@ var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true},
 					return this === document.activeElement;
 				},
 				set: function(val){
-					var cur = attr.get(this, "focused");
-					if(cur !== val) {
-						var element = this;
-						types.queueTask([function(){
-							if(val) {
-								element.focus();
-							} else {
-								element.blur();
-							}
-						}, this, []]);
+					var cur = attr.get(this, 'focused');
+					var docEl = this.ownerDocument.documentElement;
+					var element = this;
+					function focusTask() {
+						if (val) {
+							element.focus();
+						} else {
+							element.blur();
+						}                            		
+					}
+					if (cur !== val) {
+						if (!domContains.call(docEl, element)) {
+							var initialSetHandler = function () {
+								domEvents.removeEventListener.call(element, 'inserted', initialSetHandler);
+								focusTask();
+							};
+							domEvents.addEventListener.call(element, 'inserted', initialSetHandler);
+						} else {
+							types.queueTask([
+								focusTask,
+								this,
+								[]
+							]);
+						}
 					}
 					return !!val;
 				},

--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -17,6 +17,7 @@ var types = require("can-types");
 var diff = require('../../js/diff/diff');
 
 require("../events/attributes/attributes");
+require("../events/inserted/inserted");
 
 var namespaces = {
 	'xlink': 'http://www.w3.org/1999/xlink'


### PR DESCRIPTION
This solves the problem where a stache binding like {($focused)}="show" doesn't focus the element if show is true at the time the stache is rendered (since the element isn't yet on the DOM).

Fixes #263 