### PR TITLE
Prefer making events with ownerDocument

### DIFF
--- a/dom/events/events.js
+++ b/dom/events/events.js
@@ -30,10 +30,10 @@ module.exports = {
 		return (this.nodeName && (this.nodeType === 1 || this.nodeType === 9)) || this === window;
 	},
 	dispatch: function(event, args, bubbles){
-		var doc = _document();
 		var ret;
 		var dispatchingOnDisabled = fixSyntheticEventsOnDisabled && isDispatchingOnDisabled(this, event);
 
+		var doc = this.ownerDocument || _document();
 		var ev = doc.createEvent('HTMLEvents');
 		var isString = typeof event === "string";
 


### PR DESCRIPTION
If provided, [`Node.ownerDocument`](https://developer.mozilla.org/en-US/docs/Web/API/Node/ownerDocument) is much better for creating events than the current document. This issue became apparent in `can-stache-bindings` when doing asynchronous tests of both DOM and VDOM (`can-simple-dom`) documents. This fix address that immediate issue and potentially others.