### PR TITLE
Making test for KeyboardEvent work with jQuery

### DIFF
--- a/dom/events/enter/enter-test.js
+++ b/dom/events/enter/enter-test.js
@@ -14,6 +14,9 @@ function makeKeyboardEvent() {
 		event = new KeyboardEvent("keyup", {
 			key: "Enter"
 		});
+		Object.defineProperty(event, "type", {
+			value: "keyup"
+		});
 		return event;
 	} catch (e) {
 		event = document.createEvent("KeyboardEvent");


### PR DESCRIPTION
jQuery calls `event.hasOwnProperty('type')` which fails and ends up
throwing an error with KeyboardEvents.

closes https://github.com/canjs/can-jquery/issues/85.