### PR TITLE
Safe attributes event

### DIFF
--- a/dom/events/attributes/attributes.js
+++ b/dom/events/attributes/attributes.js
@@ -6,9 +6,89 @@ var domData = require("../../data/data");
 var getMutationObserver = require("../../mutation-observer/mutation-observer");
 var assign = require("../../../js/assign/assign");
 var domDispatch = require("../../dispatch/dispatch");
+var CIDSet = require('../../../js/cid-set/cid-set');
 
-var originalAdd = events.addEventListener,
-	originalRemove = events.removeEventListener;
+var attributesEventType = 'attributes';
+
+// This flag is used in can-util/dom/attr
+// to dispatch the "attributes" event when
+// MutationObserver is not supported.
+var attributesFlagKey = 'canHasAttributesBindings';
+
+var attributesObserverKey = 'canAttributesObserver';
+
+// We need to track the handlers associated with
+// the observer so we know when to disconnect it.
+var attributesListenersKey = 'canAttributeListeners';
+
+function isMutationSupported (target) {
+	var hasObserver = !!getMutationObserver();
+	var isInDocument = isOfGlobalDocument(target);
+	return isInDocument && hasObserver;
+}
+
+function hasListeners (target) {
+	var listeners = domData.get.call(target, attributesListenersKey);
+	var hasExistingListeners = listeners && listeners.size > 0;
+	return hasExistingListeners;
+}
+
+function startObserving (target) {
+	if (hasListeners(target)) {
+		return;
+	}
+
+	if (!isMutationSupported(target)) {
+		domData.set.call(target, attributesFlagKey, true);
+		return;
+	}
+
+	var MutationObserver = getMutationObserver();
+	var observer = new MutationObserver(function (mutations) {
+		mutations.forEach(function (mutation) {
+			var eventData = assign({}, mutation);
+			domDispatch.call(target, eventData, [], false);
+		});
+	});
+	observer.observe(target, {
+		attributes: true,
+		attributeOldValue: true
+	});
+	domData.set.call(target, "canAttributesObserver", observer);
+}
+
+function stopObserving (target) {
+	if (hasListeners(target)) {
+		return;
+	}
+
+	domData.clean.call(target, attributesFlagKey);
+
+	var observer = domData.get.call(target, "canAttributesObserver");
+	if (observer && observer.disconnect) {
+		observer.disconnect();
+	}
+	domData.clean.call(target, attributesObserverKey);
+}
+
+function addListener (target, handler) {
+	var listeners = domData.get.call(target, attributesListenersKey) || new CIDSet();
+	listeners.add(handler);
+	domData.set.call(target, attributesListenersKey, listeners);
+}
+
+function removeListener (target, handler) {
+	var listeners = domData.get.call(target, attributesListenersKey);
+	if (listeners) {
+		listeners["delete"](handler);
+		if (listeners.size <= 0) {
+			domData.clean.call(target, attributesListenersKey);
+		}
+	}
+}
+
+var originalAdd = events.addEventListener;
+var originalRemove = events.removeEventListener;
 
 /**
  * @module {events} can-util/dom/events/attributes/attributes attributes
@@ -25,52 +105,24 @@ var originalAdd = events.addEventListener,
  * function attributesHandler() {
  * 	console.log("attributes event fired");
  * }
- * 
+ *
  * events.addEventListener.call(el, "attributes", attributesHandler, false);
  *
  * events.removeEventListener.call(el, "attributes", attributesHandler);
  * ```
  */
-events.addEventListener = function(eventName){
-	if(eventName === "attributes") {
-		var MutationObserver = getMutationObserver();
-		if( isOfGlobalDocument(this) && MutationObserver ) {
-			var self = this;
-			var observer = new MutationObserver(function (mutations) {
-				mutations.forEach(function (mutation) {
-					var copy = assign({}, mutation);
-					domDispatch.call(self, copy, [], false);
-				});
-
-			});
-			observer.observe(this, {
-				attributes: true,
-				attributeOldValue: true
-			});
-			domData.set.call(this, "canAttributesObserver", observer);
-		} else {
-			domData.set.call(this, "canHasAttributesBindings", true);
-		}
+events.addEventListener = function(eventName, handler) {
+	if(eventName === attributesEventType) {
+		startObserving(this);
+		addListener(handler);
 	}
 	return originalAdd.apply(this, arguments);
-
 };
 
-events.removeEventListener = function(eventName){
-	if(eventName === "attributes") {
-		var MutationObserver = getMutationObserver();
-		var observer;
-
-		if(isOfGlobalDocument(this) && MutationObserver) {
-			observer = domData.get.call(this, "canAttributesObserver");
-
-			if (observer && observer.disconnect) {
-				observer.disconnect();
-				domData.clean.call(this, "canAttributesObserver");
-			}
-		} else {
-			domData.clean.call(this, "canHasAttributesBindings");
-		}
+events.removeEventListener = function(eventName, handler) {
+	if(eventName === attributesEventType) {
+		removeListener(this, handler);
+		stopObserving(this);
 	}
 	return originalRemove.apply(this, arguments);
 };

--- a/dom/events/attributes/attributes.js
+++ b/dom/events/attributes/attributes.js
@@ -114,7 +114,7 @@ var originalRemove = events.removeEventListener;
 events.addEventListener = function(eventName, handler) {
 	if(eventName === attributesEventType) {
 		startObserving(this);
-		addListener(handler);
+		addListener(this, handler);
 	}
 	return originalAdd.apply(this, arguments);
 };

--- a/dom/events/attributes/attributes.js
+++ b/dom/events/attributes/attributes.js
@@ -54,7 +54,7 @@ function startObserving (target) {
 		attributes: true,
 		attributeOldValue: true
 	});
-	domData.set.call(target, "canAttributesObserver", observer);
+	domData.set.call(target, attributesObserverKey, observer);
 }
 
 function stopObserving (target) {
@@ -64,7 +64,7 @@ function stopObserving (target) {
 
 	domData.clean.call(target, attributesFlagKey);
 
-	var observer = domData.get.call(target, "canAttributesObserver");
+	var observer = domData.get.call(target, attributesObserverKey);
 	if (observer && observer.disconnect) {
 		observer.disconnect();
 	}


### PR DESCRIPTION
This makes the `attributes` event memory safe and also cleans up much of the logic to make breaking it out into a new package easier (also more readable now).