### PR TITLE
Deprecate is-array and is-string

### DIFF
--- a/js/deep-assign/deep-assign.js
+++ b/js/deep-assign/deep-assign.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var isArray = require('../is-array/is-array');
 var isFunction = require('../is-function/is-function');
 var isPlainObject = require('../is-plain-object/is-plain-object');
 
@@ -37,10 +36,10 @@ function deepAssign() {
 				}
 
 				// Recurse if we're merging plain objects or arrays
-				if (copy && (isPlainObject(copy) || (copyIsArray = isArray(copy)))) {
+				if (copy && (isPlainObject(copy) || (copyIsArray = Array.isArray(copy)))) {
 					if (copyIsArray) {
 						copyIsArray = false;
-						clone = src && isArray(src) ? src : [];
+						clone = src && Array.isArray(src) ? src : [];
 
 					} else {
 						clone = src && isPlainObject(src) ? src : {};

--- a/js/is-array/is-array.js
+++ b/js/is-array/is-array.js
@@ -1,5 +1,15 @@
 'use strict';
 
+var dev = require('../dev/dev');
+var hasWarned = false;
+
 module.exports = function(arr) {
+	//!steal-remove-start
+	if (!hasWarned) {
+		dev.warn('js/is-array/is-array is deprecated; use Array.isArray');
+		hasWarned = true;
+	}
+	//!steal-remove-end
+
 	return Array.isArray(arr);
 };

--- a/js/is-string/is-string.js
+++ b/js/is-string/is-string.js
@@ -1,5 +1,8 @@
 'use strict';
 
+var dev = require('../dev/dev');
+var hasWarned = false;
+
 /**
  * @module {function} can-util/js/is-string/is-string is-string
  * @parent can-util/js
@@ -19,5 +22,12 @@
  * @return {Boolean} True if the object is a string.
  */
 module.exports = function isString(obj){
-  return typeof obj === 'string';
+	//!steal-remove-start
+	if (!hasWarned) {
+		dev.warn('js/is-string/is-string is deprecated; use typeof x === "string"');
+		hasWarned = true;
+	}
+	//!steal-remove-end
+
+	return typeof obj === 'string';
 };


### PR DESCRIPTION
Fixes #225. Unfortunately both `is-string` and `is-array` are exposed in [the grouped utilities module](https://github.com/canjs/can-util/blob/4bc024e78e72e7e20f0ce9bbd777cbe314a0ac83/js/js.js#L14-L22) we cannot do a simple top-level deprecation like we can with param/depram.