### PR TITLE
Prevent removeDelegateListener from throwing

### DIFF
--- a/dom/events/delegate/delegate-test.js
+++ b/dom/events/delegate/delegate-test.js
@@ -40,6 +40,16 @@ if (supportsMatchesMethod) {
 		domDispatch.call(ul.firstChild.firstChild,"click");
 	});
 
+	test("can call removeDelegateListener without having previously called addDelegateListener", 1, function(){
+		try {
+			var ul = document.createElement("ul");
+			domEvents.removeDelegateListener.call(ul, "click", "li", function(){});
+			ok(true, "Calling removeDelegateListener does not throw");
+		} catch(er) {
+			ok(false, "Calling removeDelegateListener throws");
+		}
+	});
+
 	test("focus", 2, function () {
 		stop();
 		var frag = buildFrag("<div><input type='text'></div>");

--- a/dom/events/delegate/delegate.js
+++ b/dom/events/delegate/delegate.js
@@ -147,7 +147,7 @@ domEvents.addDelegateListener = function(eventType, selector, handler) {
 domEvents.removeDelegateListener = function(eventType, selector, handler) {
 	var events = domData.get.call(this, dataName);
 
-	if (events[eventType] && events[eventType][selector]) {
+	if (events && events[eventType] && events[eventType][selector]) {
 		var eventTypeEvents = events[eventType],
 			delegates = eventTypeEvents[selector],
 			i = 0;


### PR DESCRIPTION
Previously removeDelegateListener assumed that addDelegateListener had
been called on that element. This prevents that assumption.