### PR TITLE
Revert "Removing setAttributeNode"

### DIFF
--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -496,13 +496,32 @@ var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true},
 				try {
 					doc.createAttribute("{}");
 				} catch(e) {
-					return function(el, attrName, val){
-						var attr = attrName.split(':');
+					var invalidNodes = {},
+						attributeDummy = document.createElement('div');
 
-						if(attr.length !== 1 && namespaces[attr[0]]) {
-							el.setAttributeNS(namespaces[attr[0]], attrName, val);
+					return function(el, attrName, val){
+						var first = attrName.charAt(0),
+							cachedNode,
+							node,
+							attr;
+						if((first === "{" || first === "(" || first === "*") && el.setAttributeNode) {
+							cachedNode = invalidNodes[attrName];
+							if(!cachedNode) {
+								attributeDummy.innerHTML = '<div ' + attrName + '=""></div>';
+								cachedNode = invalidNodes[attrName] = attributeDummy.childNodes[0].attributes[0];
+							}
+							node = cachedNode.cloneNode();
+							node.value = val;
+							el.setAttributeNode(node);
 						} else {
-							el.setAttribute(attrName, val);
+							attr = attrName.split(':');
+
+							if(attr.length !== 1 && namespaces[attr[0]]) {
+								el.setAttributeNS(namespaces[attr[0]], attrName, val);
+							}
+							else {
+								el.setAttribute(attrName, val);
+							}
 						}
 					};
 				}


### PR DESCRIPTION
Reverts canjs/can-util#321.

This is breaking some tests in other repos... Going to revert while I sort it out.