### PR TITLE
Uncomment deprecation warnings

### DIFF
--- a/dom/ajax/ajax.js
+++ b/dom/ajax/ajax.js
@@ -8,8 +8,8 @@ var canDev = require("can-log/dev/dev");
  * @description Deprecated. Use [can-ajax] instead.
  */
 
- //!steal-remove-start
- canDev.warn('dom/ajax/ajax is deprecated; please use can-ajax instead: https://github.com/canjs/can-ajax');
- //!steal-remove-end
+//!steal-remove-start
+canDev.warn('js/ajax/ajax is deprecated; please use can-ajax instead: https://github.com/canjs/can-ajax');
+//!steal-remove-end
 
 module.exports = require('can-ajax');

--- a/dom/document/document.js
+++ b/dom/document/document.js
@@ -1,6 +1,6 @@
 'use strict';
 
-//var canDev = require("can-log/dev/dev");
+var canDev = require("can-log/dev/dev");
 
 /**
  * @module can-util/js/document/document document
@@ -8,8 +8,8 @@
  * @description Deprecated. Use [can-globals] instead.
  */
 
- //!steal-remove-start
-//  canDev.warn('js/document/document is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
- //!steal-remove-end
+//!steal-remove-start
+canDev.warn('js/document/document is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
+//!steal-remove-end
 
 module.exports = require('can-globals/document/document');

--- a/dom/events/enter/enter.js
+++ b/dom/events/enter/enter.js
@@ -26,9 +26,9 @@ var canDev = require('can-log/dev/dev');
  *
  */
 
- //!steal-remove-start
- canDev.warn('dom/events/enter/enter is deprecated; please use can-event-dom-enter instead: https://github.com/canjs/can-event-dom-enter');
- //!steal-remove-end
+//!steal-remove-start
+canDev.warn('dom/events/enter/enter is deprecated; please use can-event-dom-enter instead: https://github.com/canjs/can-event-dom-enter');
+//!steal-remove-end
 
 var addEnter = require('can-event-dom-enter/compat');
 addEnter(events);

--- a/dom/location/location.js
+++ b/dom/location/location.js
@@ -1,6 +1,6 @@
 'use strict';
 
-//var canDev = require("can-log/dev/dev");
+var canDev = require("can-log/dev/dev");
 
 /**
  * @module can-util/js/location/location location
@@ -8,8 +8,8 @@
  * @description Deprecated. Use [can-globals] instead.
  */
 
- //!steal-remove-start
-//  canDev.warn('js/location/location is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
- //!steal-remove-end
+//!steal-remove-start
+canDev.warn('js/location/localtion is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
+//!steal-remove-end
 
 module.exports = require('can-globals/location/location');

--- a/dom/mutation-observer/mutation-observer.js
+++ b/dom/mutation-observer/mutation-observer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-//var canDev = require("can-log/dev/dev");
+var canDev = require("can-log/dev/dev");
 var globals = require('can-globals');
 
 /**
@@ -10,7 +10,7 @@ var globals = require('can-globals');
  */
 
 //!steal-remove-start
-// canDev.warn('js/mutation-observer/mutation-observer is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
+canDev.warn('js/mutation-observer/mutation-observer is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
 //!steal-remove-end
 
 module.exports = function(setMO){

--- a/js/assign/assign.js
+++ b/js/assign/assign.js
@@ -1,6 +1,6 @@
 'use strict';
 
-//var canDev = require("can-log/dev/dev");
+var canDev = require("can-log/dev/dev");
 
 /**
  * @module can-util/js/assign/assign assign
@@ -8,8 +8,8 @@
  * @description Deprecated. Use [can-assign] instead.
  */
 
- //!steal-remove-start
-//  canDev.warn('js/assign/assign is deprecated; please use can-assign instead: https://github.com/canjs/can-assign');
- //!steal-remove-end
+//!steal-remove-start
+canDev.warn('js/assign/assign is deprecated; please use can-assign instead: https://github.com/canjs/can-assign');
+//!steal-remove-end
 
 module.exports = require('can-assign');

--- a/js/cid-map/cid-map.js
+++ b/js/cid-map/cid-map.js
@@ -1,6 +1,6 @@
 'use strict';
 
-//var canDev = require("can-log/dev/dev");
+var canDev = require("can-log/dev/dev");
 
 /**
  * @module can-util/js/cid-map/cid-map cid-map
@@ -9,7 +9,7 @@
  */
 
 //!steal-remove-start
-// canDev.warn('js/cid-map/cid-map is deprecated; please use can-globals instead: https://github.com/canjs/can-cid');
+canDev.warn('js/cid-map/cid-map is deprecated; please use can-globals instead: https://github.com/canjs/can-cid');
 //!steal-remove-end
 
 module.exports = require('can-cid/map/map');

--- a/js/cid-set/cid-set.js
+++ b/js/cid-set/cid-set.js
@@ -1,6 +1,6 @@
 'use strict';
 
-//var canDev = require("can-log/dev/dev");
+var canDev = require("can-log/dev/dev");
 
 /**
  * @module can-util/js/cid-set/cid-set cid-set
@@ -9,7 +9,7 @@
  */
 
 //!steal-remove-start
-// canDev.warn('js/cid-set/cid-set is deprecated; please use can-globals instead: https://github.com/canjs/can-cid');
+canDev.warn('js/cid-set/cid-set is deprecated; please use can-globals instead: https://github.com/canjs/can-cid');
 //!steal-remove-end
 
 module.exports = require('can-cid/set/set');

--- a/js/dev/dev.js
+++ b/js/dev/dev.js
@@ -1,6 +1,6 @@
 'use strict';
 
-//var canDev = require("can-log/dev/dev");
+var canDev = require("can-log/dev/dev");
 
 /**
  * @module can-util/js/dev/dev dev
@@ -8,8 +8,8 @@
  * @description Deprecated. Use [can-dev] instead.
  */
 
- //!steal-remove-start
-//  canDev.warn('js/dev/dev is deprecated; please use can-log/dev/dev instead: https://github.com/canjs/can-log');
- //!steal-remove-end
+//!steal-remove-start
+canDev.warn('js/dev/dev is deprecated; please use can-log/dev/dev instead: https://github.com/canjs/can-log');
+//!steal-remove-end
 
 module.exports = require('can-log/dev/dev');

--- a/js/global/global.js
+++ b/js/global/global.js
@@ -1,6 +1,6 @@
 'use strict';
 
-//var canDev = require("can-log/dev/dev");
+var canDev = require("can-log/dev/dev");
 
 /**
  * @module can-util/js/global/global global
@@ -9,7 +9,7 @@
  */
 
 //!steal-remove-start
-// canDev.warn('js/global/global is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
+canDev.warn('js/global/global is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
 //!steal-remove-end
 
 module.exports = require('can-globals/global/global');

--- a/js/is-browser-window/is-browser-window.js
+++ b/js/is-browser-window/is-browser-window.js
@@ -1,6 +1,6 @@
 'use strict';
 
-//var canDev = require("can-log/dev/dev");
+var canDev = require("can-log/dev/dev");
 
 /**
  * @module can-util/js/is-browser-window/is-browser-window is-browser-window
@@ -9,7 +9,7 @@
  */
 
 //!steal-remove-start
-// canDev.warn('js/is-browser-window/is-browser-window is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
+canDev.warn('js/is-browser-window/is-browser-window is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
 //!steal-remove-end
 
 module.exports = require('can-globals/is-browser-window/is-browser-window');

--- a/js/log/log.js
+++ b/js/log/log.js
@@ -1,6 +1,6 @@
 'use strict';
 
-//var canDev = require("can-log/dev/dev");
+var canDev = require("can-log/dev/dev");
 
 /**
  * @module can-util/js/log/log log
@@ -8,8 +8,8 @@
  * @description Deprecated. Use [can-log] instead.
  */
 
- //!steal-remove-start
-//  canDev.warn('js/log/log is deprecated; please use can-log instead: https://github.com/canjs/can-log');
- //!steal-remove-end
+//!steal-remove-start
+canDev.warn('js/log/log is deprecated; please use can-log instead: https://github.com/canjs/can-log');
+//!steal-remove-end
 
 module.exports = require('can-log');


### PR DESCRIPTION
These were commented out because of issues down steam caused by tests being dependent on `can-log/dev.warn`. These have since been addressed with `can-test-helpers`.