### PR TITLE
Add support for slim loader

### DIFF
--- a/js/import/import.js
+++ b/js/import/import.js
@@ -35,8 +35,13 @@ module.exports = function(moduleName, parentName) {
 			} else if(global.require){
 				resolve(global.require(moduleName));
 			} else {
-				// ideally this will use can.getObject
-				resolve();
+				// steal optimized build
+				if (typeof stealRequire !== "undefined") {
+					steal.import(moduleName, { name: parentName }).then(resolve, reject);
+				} else {
+					// ideally this will use can.getObject
+					resolve();
+				}
 			}
 		} catch(err) {
 			reject(err);


### PR DESCRIPTION
In a slim build, the global `System` is not set and `can-util/js/import/` will just resolve the import with empty module.

This change makes it so can-import checks for `stealRequire` and calls `steal.import` (which is transpiled to `stealRequire.dynamic` during the slim build) instead of resolving right away.