### PR TITLE
Make each module assign to can-namespace separately

### DIFF
--- a/can-util.js
+++ b/can-util.js
@@ -1,5 +1,6 @@
-var deepAssign = require('./js/deep-assign/deep-assign');
-var omit = require('./js/omit/omit');
 var namespace = require('can-namespace');
 
-module.exports = deepAssign(namespace, require('./dom/dom'), omit(require('./js/js'), [ 'cid', 'types' ]));
+require('./js/js');
+require('./dom/dom');
+
+module.exports = namespace;

--- a/dom/ajax/ajax.js
+++ b/dom/ajax/ajax.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var canDev = require("can-log/dev/dev");
+var namespace = require("can-namespace");
 
 /**
  * @module can-util/dom/ajax/ajax ajax
@@ -12,4 +13,4 @@ var canDev = require("can-log/dev/dev");
  canDev.warn('dom/ajax/ajax is deprecated; please use can-ajax instead: https://github.com/canjs/can-ajax');
  //!steal-remove-end
 
-module.exports = require('can-ajax');
+module.exports = namespace.ajax = require('can-ajax');

--- a/dom/attr/attr.js
+++ b/dom/attr/attr.js
@@ -3,6 +3,7 @@
 // # can/util/attr.js
 // Central location for attribute changing to occur, used to trigger an
 // `attributes` event on elements. This enables the user to do (jQuery example): `$(el).bind("attributes", function(ev) { ... })` where `ev` contains `attributeName` and `oldValue`.
+var namespace = require("can-namespace");
 var setImmediate = require("../../js/set-immediate/set-immediate");
 var getDocument = require("can-globals/document/document");
 var global = require("can-globals/global/global")();
@@ -655,4 +656,4 @@ domEvents.removeEventListener = function(eventName, handler){
 	return oldRemoveEventListener.apply(this, arguments);
 };
 
-module.exports = exports = attr;
+module.exports = namespace.attr = attr;

--- a/dom/child-nodes/child-nodes.js
+++ b/dom/child-nodes/child-nodes.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var namespace = require("can-namespace");
+
 /**
  * @module {function} can-util/dom/child-nodes/child-nodes child-nodes
  * @parent can-util/dom
@@ -35,4 +37,4 @@ function childNodes(node) {
 	}
 }
 
-module.exports = childNodes;
+module.exports = namespace.childNodes = childNodes;

--- a/dom/class-name/class-name.js
+++ b/dom/class-name/class-name.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var namespace = require("can-namespace");
+
 // From http://jaketrent.com/post/addremove-classes-raw-javascript/
 
 var has = function(className) {
@@ -23,7 +25,7 @@ var has = function(className) {
  * fooDiv.outerHTML; //-> '<div class="foo"></div>'
  * ```
  */
-module.exports = {
+module.exports = namespace.className = {
 	/**
 	 * @function can-util/dom/class-name/class-name.has className.has
 	 * @parent can-util/dom/class-name/class-name
@@ -33,7 +35,7 @@ module.exports = {
 	 *
 	 * ```js
 	 * var className = require("can-util/dom/class-name/class-name");
-	 * 
+	 *
 	 * var isContainer = className.has.call(el, "container");
 	 * ```
 	 *
@@ -51,7 +53,7 @@ module.exports = {
 	 *
 	 * ```js
 	 * var className = require("can-util/dom/class-name/class-name");
-	 * 
+	 *
 	 * className.add.call(el, "container");
 	 * ```
 	 *
@@ -76,7 +78,7 @@ module.exports = {
 	 *
 	 * ```js
 	 * var className = require("can-util/dom/class-name/class-name");
-	 * 
+	 *
 	 * className.remove.call(el, "container");
 	 * ```
 	 *

--- a/dom/contains/contains.js
+++ b/dom/contains/contains.js
@@ -1,5 +1,7 @@
 'use strict';
 
-module.exports = function(child){
+var namespace = require("can-namespace");
+
+module.exports = namespace.contains = function(child){
 	return this.contains(child);
 };

--- a/dom/data/data.js
+++ b/dom/data/data.js
@@ -2,6 +2,7 @@
 
 var domDataState = require("can-dom-data-state");
 var mutationDocument = require("../mutation-observer/document/document");
+var namespace = require("can-namespace");
 
 // count of distinct elements that have domData set
 var elementSetCount = 0;
@@ -13,7 +14,7 @@ var deleteNode = function() {
 };
 
 var cleanupDomData = function(node) {
-	
+
 	if(domDataState.get.call(node) !== undefined){
 		deleteNode.call(node);
 	}
@@ -34,7 +35,7 @@ var cleanupDomData = function(node) {
  * var domData = require("can-util/dom/data/data");
  * ```
  */
-module.exports = {
+module.exports = namespace.data = {
 	/**
 	 * @function can-util/dom/data/data.getCid domData.getCid
 	 * @signature `domData.getCid.call(el)`
@@ -74,7 +75,7 @@ module.exports = {
 	 *
 	 * ```js
 	 * var domData = require("can-util/dom/data/data");
-	 * 
+	 *
 	 * domData.clean.call(el, "metadata");
 	 * ```
 	 */
@@ -87,7 +88,7 @@ module.exports = {
 	 *
 	 * ```js
 	 * var domData = require("can-util/dom/data/data");
-	 * 
+	 *
 	 * var metadata = domData.get.call(el, "metadata");
 	 * ```
 	 *
@@ -105,7 +106,7 @@ module.exports = {
 	 *
 	 * ```js
 	 * var domData = require("can-util/dom/data/data");
-	 * 
+	 *
 	 * domData.set.call(el, "metadata", {
 	 *   foo: "bar"
 	 * });
@@ -131,12 +132,12 @@ module.exports = {
 	 *
 	 * ```js
 	 * var domData = require("can-util/dom/data/data");
-	 * 
+	 *
 	 * domData.delete.call(el);
 	 * ```
 	 */
 	delete: deleteNode,
-	
+
 	_getElementSetCount: function(){
 		return elementSetCount;
 	}

--- a/dom/dispatch/dispatch.js
+++ b/dom/dispatch/dispatch.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var domEvents = require("../events/events");
+var namespace = require("can-namespace");
 
 /**
  * @module {function} can-util/dom/dispatch/dispatch dispatch
@@ -14,6 +15,6 @@ var domEvents = require("../events/events");
  * @param {Boolean} [bubbles=true] Specifies whether this event should bubble (by default it will).
  */
 
-module.exports = function(){
+module.exports = namespace.dispatch = function() {
 	return domEvents.dispatch.apply(this, arguments);
 };

--- a/dom/document/document.js
+++ b/dom/document/document.js
@@ -1,6 +1,7 @@
 'use strict';
 
 //var canDev = require("can-log/dev/dev");
+var namespace = require("can-namespace");
 
 /**
  * @module can-util/js/document/document document
@@ -12,4 +13,4 @@
 //  canDev.warn('js/document/document is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
  //!steal-remove-end
 
-module.exports = require('can-globals/document/document');
+module.exports = namespace.document = require('can-globals/document/document');

--- a/dom/events/events.js
+++ b/dom/events/events.js
@@ -5,6 +5,7 @@ var isBrowserWindow = require('can-globals/is-browser-window/is-browser-window')
 var isPlainObject = require('../../js/is-plain-object/is-plain-object');
 var fixSyntheticEventsOnDisabled = false;
 var dev = require('can-log/dev/dev');
+var namespace = require("can-namespace");
 
 function isDispatchingOnDisabled(element, ev) {
 	var isInsertedOrRemoved = isPlainObject(ev) ? (ev.type === 'inserted' || ev.type === 'removed') : (ev === 'inserted' || ev === 'removed');
@@ -21,7 +22,7 @@ function isDispatchingOnDisabled(element, ev) {
  * var domEvents = require("can-util/dom/events/events");
  * ```
  */
-module.exports = {
+module.exports = namespace.events = {
 	addEventListener: function(){
 		this.addEventListener.apply(this, arguments);
 	},

--- a/dom/frag/frag.js
+++ b/dom/frag/frag.js
@@ -4,6 +4,7 @@ var getDocument = require('can-globals/document/document');
 var fragment = require('../fragment/fragment');
 var each = require('../../js/each/each');
 var childNodes = require('../child-nodes/child-nodes');
+var namespace = require("can-namespace");
 
 /**
 @module {function} can-util/dom/frag/frag frag
@@ -73,4 +74,4 @@ var makeFrag = function(item, doc){
 	}
 };
 
-module.exports = makeFrag;
+module.exports = namespace.frag = makeFrag;

--- a/dom/fragment/fragment.js
+++ b/dom/fragment/fragment.js
@@ -1,7 +1,9 @@
 'use strict';
 
-var getDocument = require('can-globals/document/document'),
-	childNodes = require("../child-nodes/child-nodes");
+var getDocument = require('can-globals/document/document');
+var childNodes = require("../child-nodes/child-nodes");
+var namespace = require("can-namespace");
+
 // fragment.js
 // ---------
 // _DOM Fragment support._
@@ -74,4 +76,4 @@ var buildFragment = function (html, doc) {
 // a text node that is set to the content.
 
 
-module.exports = buildFragment;
+module.exports = namespace.fragment = buildFragment;

--- a/dom/is-of-global-document/is-of-global-document.js
+++ b/dom/is-of-global-document/is-of-global-document.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var getDocument = require('can-globals/document/document');
-module.exports = function(el) {
+var namespace = require("can-namespace");
+
+module.exports = namespace.isOfGlobalDocument = function(el) {
 	return (el.ownerDocument || el) === getDocument();
 };

--- a/dom/matches/matches.js
+++ b/dom/matches/matches.js
@@ -1,11 +1,13 @@
 'use strict';
 
+var namespace = require("can-namespace");
+
 var matchesMethod = function(element) {
 	return element.matches || element.webkitMatchesSelector || element.webkitMatchesSelector ||
 		element.mozMatchesSelector || element.msMatchesSelector || element.oMatchesSelector;
 };
 
-module.exports = function(){
+module.exports = namespace.matches = function() {
 	var method = matchesMethod(this);
 	return method ? method.apply(this, arguments) : false;
 };

--- a/dom/mutate/mutate.js
+++ b/dom/mutate/mutate.js
@@ -5,6 +5,7 @@
 // Given a list of elements, check if the first is in the DOM, and if so triggers the `inserted` event on all elements and their descendants.
 
 var makeArray = require("../../js/make-array/make-array");
+var namespace = require("can-namespace");
 var setImmediate = require("../../js/set-immediate/set-immediate");
 var CID = require("can-cid");
 
@@ -111,7 +112,7 @@ var mutated = function(elements, type) {
  * mutate.appendChild.call(document.body, el);
  * ```
  */
-module.exports = {
+module.exports = namespace.mutate = {
 	/**
 	 * @function can-util/dom/mutate/mutate.appendChild appendChild
 	 * @signature `mutate.appendChild.call(el, child)`

--- a/dom/mutation-observer/mutation-observer.js
+++ b/dom/mutation-observer/mutation-observer.js
@@ -2,6 +2,7 @@
 
 //var canDev = require("can-log/dev/dev");
 var globals = require('can-globals');
+var namespace = require("can-namespace");
 
 /**
  * @module can-util/js/mutation-observer/mutation-observer mutation-observer
@@ -13,7 +14,7 @@ var globals = require('can-globals');
 // canDev.warn('js/mutation-observer/mutation-observer is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
 //!steal-remove-end
 
-module.exports = function(setMO){
+module.exports = namespace.mutationObserver = function(setMO) {
 	if(setMO !== undefined) {
 		globals.setKeyValue('MutationObserver', function(){
 			return setMO;

--- a/js/assign/assign.js
+++ b/js/assign/assign.js
@@ -1,6 +1,7 @@
 'use strict';
 
 //var canDev = require("can-log/dev/dev");
+var namespace = require("can-namespace");
 
 /**
  * @module can-util/js/assign/assign assign
@@ -12,4 +13,4 @@
 //  canDev.warn('js/assign/assign is deprecated; please use can-assign instead: https://github.com/canjs/can-assign');
  //!steal-remove-end
 
-module.exports = require('can-assign');
+module.exports = namespace.assign = require('can-assign');

--- a/js/deep-assign/deep-assign.js
+++ b/js/deep-assign/deep-assign.js
@@ -2,6 +2,7 @@
 
 var isFunction = require('../is-function/is-function');
 var isPlainObject = require('../is-plain-object/is-plain-object');
+var namespace = require("can-namespace");
 
 function deepAssign() {
 	/*jshint maxdepth:6 */
@@ -60,4 +61,4 @@ function deepAssign() {
 	return target;
 }
 
-module.exports = deepAssign;
+module.exports = namespace.deepAssign = deepAssign;

--- a/js/dev/dev.js
+++ b/js/dev/dev.js
@@ -1,6 +1,7 @@
 'use strict';
 
 //var canDev = require("can-log/dev/dev");
+var namespace = require("can-namespace");
 
 /**
  * @module can-util/js/dev/dev dev
@@ -12,4 +13,4 @@
 //  canDev.warn('js/dev/dev is deprecated; please use can-log/dev/dev instead: https://github.com/canjs/can-log');
  //!steal-remove-end
 
-module.exports = require('can-log/dev/dev');
+module.exports = namespace.dev = require('can-log/dev/dev');

--- a/js/diff/diff.js
+++ b/js/diff/diff.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var namespace = require("can-namespace");
+
 var slice = [].slice;
 // a b c
 // a b c d
@@ -78,7 +80,7 @@ function reverseDiff(oldDiffStopIndex, newDiffStopIndex, oldList, newList, ident
 //    @param {can-util/diff/diff/typedefs.identity} identity(a, b)
 //    @option {*} a
 
-module.exports = exports = function(oldList, newList, identity){
+module.exports = namespace.diff = function(oldList, newList, identity){
 	identity = identity || defaultIdentity;
 
 	var oldIndex = 0,

--- a/js/each/each.js
+++ b/js/each/each.js
@@ -5,6 +5,7 @@ var isArrayLike = require('../is-array-like/is-array-like');
 var has = Object.prototype.hasOwnProperty;
 var isIterable = require("../is-iterable/is-iterable");
 var canSymbol = require("can-symbol");
+var namespace = require("can-namespace");
 
 function each(elements, callback, context) {
 	var i = 0,
@@ -45,4 +46,4 @@ function each(elements, callback, context) {
 	return elements;
 }
 
-module.exports = each;
+module.exports = namespace.each = each;

--- a/js/global/global.js
+++ b/js/global/global.js
@@ -1,6 +1,7 @@
 'use strict';
 
 //var canDev = require("can-log/dev/dev");
+var namespace = require("can-namespace");
 
 /**
  * @module can-util/js/global/global global
@@ -12,4 +13,4 @@
 // canDev.warn('js/global/global is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
 //!steal-remove-end
 
-module.exports = require('can-globals/global/global');
+module.exports = namespace.global = require('can-globals/global/global');

--- a/js/import/import.js
+++ b/js/import/import.js
@@ -2,6 +2,7 @@
 
 var isFunction = require('../is-function/is-function');
 var global = require('can-globals/global/global')();
+var namespace = require("can-namespace");
 
 /**
  * @module {function} can-util/js/import/import import
@@ -21,7 +22,7 @@ var global = require('can-globals/global/global')();
  * @return {Promise} A Promise that will resolve when the module has been imported.
  */
 
-module.exports = function(moduleName, parentName) {
+module.exports = namespace.import = function(moduleName, parentName) {
 	return new Promise(function(resolve, reject) {
 		try {
 			if(typeof global.System === "object" && isFunction(global.System["import"])) {

--- a/js/is-array-like/is-array-like.js
+++ b/js/is-array-like/is-array-like.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var namespace = require("can-namespace");
+
 // The following is from jQuery
 function isArrayLike(obj){
 	var type = typeof obj;
@@ -20,4 +22,4 @@ function isArrayLike(obj){
 		( length === 0 || typeof length === "number" && length > 0 && ( length - 1 ) in obj );
 }
 
-module.exports = isArrayLike;
+module.exports = namespace.isArrayLike = isArrayLike;

--- a/js/is-array/is-array.js
+++ b/js/is-array/is-array.js
@@ -1,9 +1,11 @@
 'use strict';
 
 var dev = require('can-log/dev/dev');
+var namespace = require("can-namespace");
+
 var hasWarned = false;
 
-module.exports = function(arr) {
+module.exports = namespace.isArray = function(arr) {
 	//!steal-remove-start
 	if (!hasWarned) {
 		dev.warn('js/is-array/is-array is deprecated; use Array.isArray');

--- a/js/is-browser-window/is-browser-window.js
+++ b/js/is-browser-window/is-browser-window.js
@@ -1,6 +1,7 @@
 'use strict';
 
 //var canDev = require("can-log/dev/dev");
+var namespace = require("can-namespace");
 
 /**
  * @module can-util/js/is-browser-window/is-browser-window is-browser-window
@@ -12,4 +13,4 @@
 // canDev.warn('js/is-browser-window/is-browser-window is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
 //!steal-remove-end
 
-module.exports = require('can-globals/is-browser-window/is-browser-window');
+module.exports = namespace.isBrowserWindow = require('can-globals/is-browser-window/is-browser-window');

--- a/js/is-empty-object/is-empty-object.js
+++ b/js/is-empty-object/is-empty-object.js
@@ -2,6 +2,8 @@
 
 /* jshint unused: false */
 
+var namespace = require("can-namespace");
+
 /**
  * @module {function} can-util/js/is-empty-object/is-empty-object is-empty-object
  * @parent can-util/js
@@ -27,7 +29,7 @@
  * @param {Object} obj Any object.
  * @return {Boolean} True if the object is an object with no enumerable properties.
  */
-module.exports = function(obj){
+module.exports = namespace.isEmptyObject = function(obj) {
 	for(var prop in obj) {
 		return false;
 	}

--- a/js/is-function/is-function.js
+++ b/js/is-function/is-function.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var namespace = require("can-namespace");
+
 /**
  * @module {function} can-util/js/is-function/is-function is-function
  * @parent can-util/js
@@ -29,4 +31,4 @@ var isFunction = (function() {
 	};
 }());
 
-module.exports = isFunction;
+module.exports = namespace.isFunction = isFunction;

--- a/js/is-node/is-node.js
+++ b/js/is-node/is-node.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var namespace = require("can-namespace");
+
 /**
  * @module {function} can-util/js/is-node/is-node is-node
  * @parent can-util/js
@@ -18,7 +20,7 @@
  * @return {Boolean} True if running in Node.js
  */
 
-module.exports = function(){
+module.exports = namespace.isNode = function() {
 	return typeof process === "object" &&
 		{}.toString.call(process) === "[object process]";
 };

--- a/js/is-plain-object/is-plain-object.js
+++ b/js/is-plain-object/is-plain-object.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var namespace = require("can-namespace");
+
 var core_hasOwn = Object.prototype.hasOwnProperty;
 
 function isWindow(obj) {
@@ -31,4 +33,4 @@ function isPlainObject(obj) {
 	return key === undefined || core_hasOwn.call(obj, key);
 }
 
-module.exports = isPlainObject;
+module.exports = namespace.isPlainObject = isPlainObject;

--- a/js/is-promise/is-promise.js
+++ b/js/is-promise/is-promise.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var canReflect = require('can-reflect');
+var namespace = require("can-namespace");
+
 /**
  * @module {function} can-util/js/is-promise/is-promise is-promise
  * @parent can-util/js
@@ -22,6 +24,6 @@ var canReflect = require('can-reflect');
  * @param {Object} obj An object to be tested.
  * @return {Boolean} True if the object is a Promise.
  */
-module.exports = function(obj) {
+module.exports = namespace.isPromise = function(obj) {
 	return canReflect.isPromise(obj);
 };

--- a/js/is-string/is-string.js
+++ b/js/is-string/is-string.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var dev = require('can-log/dev/dev');
+var namespace = require("can-namespace");
+
 var hasWarned = false;
 
 /**
@@ -26,7 +28,7 @@ var hasWarned = false;
  * @param {*} obj An object to test if is a string.
  * @return {Boolean} True if the object is a string.
  */
-module.exports = function isString(obj){
+module.exports = namespace.isString = function isString(obj) {
 	//!steal-remove-start
 	if (!hasWarned) {
 		dev.warn('js/is-string/is-string is deprecated; use typeof x === "string"');

--- a/js/is-web-worker/is-web-worker.js
+++ b/js/is-web-worker/is-web-worker.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var namespace = require("can-namespace");
+
 /**
  * @module {function} can-util/js/is-web-worker/is-web-worker is-web-worker
  * @parent can-util/js
@@ -19,7 +21,7 @@
  */
 
 /* globals WorkerGlobalScope */
-module.exports = function(){
+module.exports = namespace.isWebWorker = function() {
 	return typeof WorkerGlobalScope !== "undefined" &&
 		(this instanceof WorkerGlobalScope);
 };

--- a/js/join-uris/join-uris.js
+++ b/js/join-uris/join-uris.js
@@ -1,8 +1,9 @@
 'use strict';
 
+var namespace = require("can-namespace");
 var parseURI = require('can-parse-uri');
 
-module.exports = function(base, href) {
+module.exports = namespace.joinURIs = function(base, href) {
 	function removeDotSegments(input) {
 		var output = [];
 		input.replace(/^(\.\.?(\/|$))+/, '')

--- a/js/js.js
+++ b/js/js.js
@@ -3,7 +3,7 @@
 
 
 module.exports = {
-	assign: require('can-assign'),
+	assign: require('./assign/assign'),
 	cid: require('can-cid'),
 	deepAssign: require('./deep-assign/deep-assign'),
 	dev: require('./dev/dev'),

--- a/js/last/last.js
+++ b/js/last/last.js
@@ -1,5 +1,7 @@
 'use strict';
 
-module.exports = function(arr){
+var namespace = require("can-namespace");
+
+module.exports = namespace.last = function(arr) {
 	return arr && arr[arr.length - 1];
 };

--- a/js/make-array/make-array.js
+++ b/js/make-array/make-array.js
@@ -2,6 +2,7 @@
 
 var each = require('../each/each');
 var isArrayLike = require('../is-array-like/is-array-like');
+var namespace = require("can-namespace");
 
 /**
  * @module {function} can-util/js/make-array/make-array make-array
@@ -11,12 +12,12 @@ var isArrayLike = require('../is-array-like/is-array-like');
  * @return {Array}     a JavaScript array object with the same elements as the passed-in ArrayLike
  *
  * makeArray takes any array-like object (can-list, NodeList, etc.) and converts it to a JavaScript array
- * 
+ *
  * ```
  * var makeArray = require("can-util/js/make-array/make-array");
- * 
+ *
  * makeArray({0: "a", length: 1}); //-> ["a"]
- * 
+ *
  * ```
  */
 function makeArray(element) {
@@ -31,4 +32,4 @@ function makeArray(element) {
 	return ret;
 }
 
-module.exports = makeArray;
+module.exports = namespace.makeArray = makeArray;

--- a/js/omit/omit.js
+++ b/js/omit/omit.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var namespace = require("can-namespace");
+
 /**
  * @module {function} can-util/js/omit/omit omit
  * @parent can-util/js
@@ -22,7 +24,7 @@
  *
  * @return {Object} Returns a new object with all of the properties from `source` that were not omitted.
  */
-module.exports = function (source, propsToOmit) {
+module.exports = namespace.omit = function (source, propsToOmit) {
 	var result = {};
 	for (var prop in source) {
 		if (propsToOmit.indexOf(prop) < 0) {

--- a/js/set-immediate/set-immediate.js
+++ b/js/set-immediate/set-immediate.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var global = require('can-globals/global/global')();
+var namespace = require("can-namespace");
 
 /**
  * @module can-util/js/set-immediate/set-immediate set-immediate
@@ -10,6 +11,6 @@ var global = require('can-globals/global/global')();
  *
  * Polyfill for setImmediate() if it doesn't exist in the global context
  */
-module.exports = global.setImmediate || function (cb) {
+module.exports = namespace.setImmediate = global.setImmediate || function (cb) {
 	return setTimeout(cb, 0);
 };

--- a/js/string/string.js
+++ b/js/string/string.js
@@ -4,6 +4,7 @@ var get = require('../get/get');
 var isContainer = require('../is-container/is-container');
 var canDev = require("can-log/dev/dev");
 var isArray = require('../is-array/is-array');
+var namespace = require("can-namespace");
 
 // ##string.js
 // _Miscellaneous string utility functions._
@@ -53,10 +54,10 @@ var string = {
 	 * @signature `string.esc(content)`
 	 * @param  {String} content a string
 	 * @return {String}         the string safely HTML-escaped
-	 * 
+	 *
 	 * ```js
 	 * var string = require("can-util/js/string/string");
-	 * 
+	 *
 	 * string.esc("<div>&nbsp;</div>"); //-> "&lt;div&gt;&amp;nbsp;&lt;/div&gt;"
 	 * ```
 	 */
@@ -89,7 +90,7 @@ var string = {
 	 *
 	 * ```js
 	 * var string = require("can-util/js/string/string");
-	 * 
+	 *
 	 * console.log(string.getObject("a.b.c", {a: {b: {c: "foo"}}})); // -> "foo"
 	 * console.log(string.getObject("a.b.c", {a: {}})); // -> undefined
 	 * console.log(string.getObject("a.b", [{a: {}}, {a: {b: "bar"}}])); // -> "bar"
@@ -274,4 +275,4 @@ var string = {
 	 */
 	undHash: strUndHash
 };
-module.exports = string;
+module.exports = namespace.string = string;


### PR DESCRIPTION
Importing can-util/can-util.js causes all of the dom/js modules to be assigned to can-namespace. This is useful but prevents can-util from being imported into the main 4.0 build because some of the modules depend on different package versions that conflict in 4.0

This commit changes how modules are assigned to can-namespace; now, each module is responsible for doing it on its own, instead of having them all done in can-util.js, which means parts of can-util can be imported and assigned to the main namespace while avoiding dependency version conflicts in 4.0

This will help fix https://github.com/canjs/canjs/issues/4041 for 4.0