### PR TITLE
fix dev code for webpack compatibility

### DIFF
--- a/dom/ajax/ajax.js
+++ b/dom/ajax/ajax.js
@@ -10,7 +10,9 @@ var namespace = require("can-namespace");
  */
 
  //!steal-remove-start
- canDev.warn('dom/ajax/ajax is deprecated; please use can-ajax instead: https://github.com/canjs/can-ajax');
+if (process.env.NODE_ENV !== 'production') {
+	canDev.warn('dom/ajax/ajax is deprecated; please use can-ajax instead: https://github.com/canjs/can-ajax');
+}
  //!steal-remove-end
 
 module.exports = namespace.ajax = require('can-ajax');

--- a/dom/document/document.js
+++ b/dom/document/document.js
@@ -10,7 +10,9 @@ var namespace = require("can-namespace");
  */
 
  //!steal-remove-start
+if (process.env.NODE_ENV !== 'production') {
 //  canDev.warn('js/document/document is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
+}
  //!steal-remove-end
 
 module.exports = namespace.document = require('can-globals/document/document');

--- a/dom/events/enter/enter.js
+++ b/dom/events/enter/enter.js
@@ -27,7 +27,9 @@ var canDev = require('can-log/dev/dev');
  */
 
  //!steal-remove-start
- canDev.warn('dom/events/enter/enter is deprecated; please use can-event-dom-enter instead: https://github.com/canjs/can-event-dom-enter');
+if (process.env.NODE_ENV !== 'production') {
+	canDev.warn('dom/events/enter/enter is deprecated; please use can-event-dom-enter instead: https://github.com/canjs/can-event-dom-enter');
+}
  //!steal-remove-end
 
 var addEnter = require('can-event-dom-enter/compat');

--- a/dom/events/events.js
+++ b/dom/events/events.js
@@ -54,11 +54,13 @@ module.exports = namespace.events = {
 		// ignore events from feature detection below
 		if(this.disabled === true && ev.type !== 'fix_synthetic_events_on_disabled_test') {
 			//!steal-remove-start
-			dev.warn(
-				"can-util/dom/events::dispatch: Dispatching a synthetic event on a disabled is " +
-				"problematic in FireFox and Internet Explorer. We recommend avoiding this if at " +
-				"all possible. see https://github.com/canjs/can-util/issues/294"
-			);
+			if (process.env.NODE_ENV !== 'production') {
+				dev.warn(
+					"can-util/dom/events::dispatch: Dispatching a synthetic event on a disabled is " +
+					"problematic in FireFox and Internet Explorer. We recommend avoiding this if at " +
+					"all possible. see https://github.com/canjs/can-util/issues/294"
+				);
+			}
 			//!steal-remove-end
 		}
 

--- a/dom/events/radiochange/radiochange.js
+++ b/dom/events/radiochange/radiochange.js
@@ -27,7 +27,9 @@ var canDev = require('can-log/dev/dev');
  */
 
 //!steal-remove-start
-canDev.warn('dom/events/radiochange/radiochange is deprecated; please use can-event-dom-radiochange instead: https://github.com/canjs/can-event-dom-radiochange');
+if (process.env.NODE_ENV !== 'production') {
+	canDev.warn('dom/events/radiochange/radiochange is deprecated; please use can-event-dom-radiochange instead: https://github.com/canjs/can-event-dom-radiochange');
+}
 //!steal-remove-end
 
 var addRadioChange = require('can-event-dom-radiochange/compat');

--- a/dom/location/location.js
+++ b/dom/location/location.js
@@ -9,7 +9,9 @@
  */
 
  //!steal-remove-start
-//  canDev.warn('js/location/location is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
+if (process.env.NODE_ENV !== 'production') {
+	//  canDev.warn('js/location/location is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
+}
  //!steal-remove-end
 
 module.exports = require('can-globals/location/location');

--- a/dom/mutation-observer/mutation-observer.js
+++ b/dom/mutation-observer/mutation-observer.js
@@ -11,7 +11,9 @@ var namespace = require("can-namespace");
  */
 
 //!steal-remove-start
-// canDev.warn('js/mutation-observer/mutation-observer is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
+if (process.env.NODE_ENV !== 'production') {
+	// canDev.warn('js/mutation-observer/mutation-observer is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
+}
 //!steal-remove-end
 
 module.exports = namespace.mutationObserver = function(setMO) {

--- a/js/assign/assign.js
+++ b/js/assign/assign.js
@@ -10,7 +10,9 @@ var namespace = require("can-namespace");
  */
 
  //!steal-remove-start
-//  canDev.warn('js/assign/assign is deprecated; please use can-assign instead: https://github.com/canjs/can-assign');
+if (process.env.NODE_ENV !== 'production') {
+	//  canDev.warn('js/assign/assign is deprecated; please use can-assign instead: https://github.com/canjs/can-assign');
+}
  //!steal-remove-end
 
 module.exports = namespace.assign = require('can-assign');

--- a/js/cid-set/cid-set.js
+++ b/js/cid-set/cid-set.js
@@ -9,7 +9,9 @@
  */
 
 //!steal-remove-start
-// canDev.warn('js/cid-set/cid-set is deprecated; please use can-globals instead: https://github.com/canjs/can-cid');
+if (process.env.NODE_ENV !== 'production') {
+	// canDev.warn('js/cid-set/cid-set is deprecated; please use can-globals instead: https://github.com/canjs/can-cid');
+}
 //!steal-remove-end
 
 module.exports = require('can-cid/set/set');

--- a/js/cid/cid.js
+++ b/js/cid/cid.js
@@ -9,7 +9,9 @@ var canDev = require("can-log/dev/dev");
  */
 
 //!steal-remove-start
-canDev.warn('js/cid/cid is deprecated; please use can-cid instead: https://github.com/canjs/can-cid');
+if (process.env.NODE_ENV !== 'production') {
+	canDev.warn('js/cid/cid is deprecated; please use can-cid instead: https://github.com/canjs/can-cid');
+}
 //!steal-remove-end
 
 module.exports = require('can-cid');

--- a/js/deparam/deparam.js
+++ b/js/deparam/deparam.js
@@ -9,7 +9,9 @@ var canDev = require("can-log/dev/dev");
  */
 
  //!steal-remove-start
+if (process.env.NODE_ENV !== 'production') {
  canDev.warn('js/deparam/deparam is deprecated; please use can-deparam instead: https://github.com/canjs/can-deparam');
+}
  //!steal-remove-end
 
 module.exports = require('can-deparam');

--- a/js/dev/dev.js
+++ b/js/dev/dev.js
@@ -10,7 +10,9 @@ var namespace = require("can-namespace");
  */
 
  //!steal-remove-start
-//  canDev.warn('js/dev/dev is deprecated; please use can-log/dev/dev instead: https://github.com/canjs/can-log');
+if (process.env.NODE_ENV !== 'production') {
+	//  canDev.warn('js/dev/dev is deprecated; please use can-log/dev/dev instead: https://github.com/canjs/can-log');
+}
  //!steal-remove-end
 
 module.exports = namespace.dev = require('can-log/dev/dev');

--- a/js/global/global.js
+++ b/js/global/global.js
@@ -10,7 +10,9 @@ var namespace = require("can-namespace");
  */
 
 //!steal-remove-start
-// canDev.warn('js/global/global is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
+if (process.env.NODE_ENV !== 'production') {
+	// canDev.warn('js/global/global is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
+}
 //!steal-remove-end
 
 module.exports = namespace.global = require('can-globals/global/global');

--- a/js/is-browser-window/is-browser-window.js
+++ b/js/is-browser-window/is-browser-window.js
@@ -10,7 +10,9 @@ var namespace = require("can-namespace");
  */
 
 //!steal-remove-start
-// canDev.warn('js/is-browser-window/is-browser-window is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
+if (process.env.NODE_ENV !== 'production') {
+	// canDev.warn('js/is-browser-window/is-browser-window is deprecated; please use can-globals instead: https://github.com/canjs/can-globals');
+}
 //!steal-remove-end
 
 module.exports = namespace.isBrowserWindow = require('can-globals/is-browser-window/is-browser-window');

--- a/js/is-string/is-string.js
+++ b/js/is-string/is-string.js
@@ -30,9 +30,11 @@ var hasWarned = false;
  */
 module.exports = namespace.isString = function isString(obj) {
 	//!steal-remove-start
-	if (!hasWarned) {
-		dev.warn('js/is-string/is-string is deprecated; use typeof x === "string"');
-		hasWarned = true;
+	if (process.env.NODE_ENV !== 'production') {
+		if (!hasWarned) {
+			dev.warn('js/is-string/is-string is deprecated; use typeof x === "string"');
+			hasWarned = true;
+		}
 	}
 	//!steal-remove-end
 

--- a/js/log/log.js
+++ b/js/log/log.js
@@ -9,7 +9,9 @@
  */
 
  //!steal-remove-start
-//  canDev.warn('js/log/log is deprecated; please use can-log instead: https://github.com/canjs/can-log');
+if (process.env.NODE_ENV !== 'production') {
+	//  canDev.warn('js/log/log is deprecated; please use can-log instead: https://github.com/canjs/can-log');
+}
  //!steal-remove-end
 
 module.exports = require('can-log');

--- a/js/param/param.js
+++ b/js/param/param.js
@@ -9,7 +9,9 @@ var canDev = require("can-log/dev/dev");
  */
 
  //!steal-remove-start
- canDev.warn('js/param/param is deprecated; please use can-param instead: https://github.com/canjs/can-param');
+if (process.env.NODE_ENV !== 'production') {
+	canDev.warn('js/param/param is deprecated; please use can-param instead: https://github.com/canjs/can-param');
+}
  //!steal-remove-end
 
 module.exports = require('can-param');

--- a/js/parse-uri/parse-uri.js
+++ b/js/parse-uri/parse-uri.js
@@ -9,7 +9,9 @@ var canDev = require("can-log/dev/dev");
  */
 
  //!steal-remove-start
+if (process.env.NODE_ENV !== 'production') {
  canDev.warn('js/parse-uri/parse-uri is deprecated; please use can-parse-uri instead: https://github.com/canjs/can-parse-uri');
+}
  //!steal-remove-end
 
 module.exports = require('can-parse-uri');

--- a/js/string/string.js
+++ b/js/string/string.js
@@ -98,7 +98,9 @@ var string = {
 	 */
 	getObject: function (name, roots) {
 		//!steal-remove-start
-		canDev.warn('string.getObject is deprecated, please use can-util/js/get/get instead.');
+		if (process.env.NODE_ENV !== 'production') {
+			canDev.warn('string.getObject is deprecated, please use can-util/js/get/get instead.');
+		}
 		//!steal-remove-end
 
 		roots = isArray(roots) ? roots : [roots || window];

--- a/js/types/types.js
+++ b/js/types/types.js
@@ -9,7 +9,9 @@ var canDev = require("can-log/dev/dev");
  */
 
 //!steal-remove-start
-canDev.warn('js/types/types is deprecated; please use can-types instead: https://github.com/canjs/can-types');
+if (process.env.NODE_ENV !== 'production') {
+	canDev.warn('js/types/types is deprecated; please use can-types instead: https://github.com/canjs/can-types');
+}
 //!steal-remove-end
 
 module.exports = require('can-types');


### PR DESCRIPTION
This fixes the first part of this issue canjs/canjs#4170 to remove debug code from the production builds.